### PR TITLE
  Fix: Incorrect fee calculations for recipients with multiple validators

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 /pgdata
 /data
+/rewards
 
 *.dump

--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ rounds:
     eth_apr: 0.047 # ETH Staking APR
     ssv_eth: 0.0088235294 # SSV/ETH price
 
-    # `network_fee` (optional) is the network fee in Gwei (1 SSV = 1e9 Gwei)
+    # `network_fee` (optional) is the network fee in SSV
     # that will be proportionally deducted from rewards for the round.
-    # Example: To specify a fee of 0.1 SSV, use 100_000_000 (0.1 * 1e9) Gwei.
+    # Example: To specify a fee of 0.1 SSV, use 0.1.
     # If omitted, no fee deduction is applied.
-    network_fee: 100_000_000  # Network fee in SSV Gwei
+    network_fee: 0.1  # Network fee in SSV
   # ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ rounds:
 First, start PostgreSQL and wait a few seconds for it to be ready:
 
 ```bash
-docker-compose up -d postgres
+docker compose up -d postgres
 ```
 
 ### Synchronization
@@ -120,7 +120,7 @@ docker-compose up -d postgres
 Synchronize validator activity and performance:
 
 ```bash
-docker-compose run --rm sync
+docker compose run --rm sync
 ```
 
 _This should sync validator performance up until 2 days ago (UTC) or until the end of the last period in `rewards.yaml` (whichever is lower). Therefore, in order to sync the last month, waiting until the 3rd of this month is required._
@@ -138,7 +138,7 @@ This caching improves performance, reduces sync time, and helps prevent hitting 
 ⚠️ By default, this cache is **deleted** when running with `--fresh` or `--fresh-ssv`.
 To preserve the `.cache` directory during a fresh sync, use the `--keep-cache` flag:
 ```bash
-docker-compose run --rm sync sync --fresh --keep-cache
+docker compose run --rm sync sync --fresh --keep-cache
 ```
 
 ### Calculation
@@ -146,7 +146,7 @@ docker-compose run --rm sync sync --fresh --keep-cache
 After syncing, you may calculate the reward distribution:
 
 ```bash
-docker-compose run --rm calc
+docker compose run --rm calc
 ```
 
 This produces the following documents under the `./rewards` directory:
@@ -185,11 +185,11 @@ After calculating the reward distribution, you may merkleize the rewards for a s
 1. Pull the changes and rebuild the Docker images:
    ```bash
    git pull
-   docker-compose build
+   docker compose build
    ```
 2. Refer to `.env.example` and update your `.env` file if necessary.
 3. Refer to `rewards.example.yaml` and update your `rewards.yaml` file if necessary.
 4. Sync with `--fresh` to re-create the databases and sync from scratch:
    ```bash
-   docker-compose run --rm sync sync --fresh
+   docker compose run --rm sync sync --fresh
    ```

--- a/cmd/ssv-rewards/calc.go
+++ b/cmd/ssv-rewards/calc.go
@@ -177,6 +177,9 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 		totalByRecipient = map[string]*RecipientParticipation{}
 	)
 
+	// Use legacy calculations before this period (defaults to 2025-08)
+	legacyBeforePeriod := c.plan.GetLegacyBeforePeriod()
+
 	for _, round := range completeRounds {
 		mechanics, err := c.plan.Mechanics.At(round.Period)
 		if err != nil {
@@ -191,58 +194,31 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 			return fmt.Errorf("failed to prepare redirections for period %s: %w", round.Period, err)
 		}
 
-		// Fetch participations
-		validatorParticipations, err := c.validatorParticipations(ctx, round.Period, mechanics, ownerRedirectsSupport, validatorRedirectsSupport)
+		var results *roundResults
+		if time.Time(round.Period).Before(time.Time(legacyBeforePeriod)) {
+			results, err = c.processRoundLegacy(ctx, logger, round, mechanics, ownerRedirectsSupport, validatorRedirectsSupport)
+		} else {
+			results, err = c.processRound(ctx, logger, round, mechanics, ownerRedirectsSupport, validatorRedirectsSupport)
+		}
 		if err != nil {
-			return fmt.Errorf("failed to get validator participations: %w", err)
+			return fmt.Errorf("failed to process round %s: %w", round.Period, err)
 		}
 
-		// Calculate appropriate tier and rewards.
-		var totalEffectiveBalanceGwei int64
-		for _, v := range validatorParticipations {
-			// TODO can it happen?
-			if v.ActiveDays == 0 {
-				continue
-			}
+		validatorParticipations := results.validatorParticipations
+		ownerParticipations := results.ownerParticipations
+		recipientParticipations := results.recipientParticipations
 
-			totalEffectiveBalanceGwei += v.TotalActiveEffectiveBalance / int64(v.ActiveDays)
-		}
-
-		tier, err := c.plan.Tier(round.Period, totalEffectiveBalanceGwei)
-		if err != nil {
-			return fmt.Errorf("failed to get tier (period: %s): %w", round.Period, err)
-		}
-		dailyReward, monthlyReward, annualReward, err := c.plan.ValidatorRewards(
-			round.Period,
-			totalEffectiveBalanceGwei,
-		)
-		if err != nil {
-			return fmt.Errorf("failed to get reward: %w", err)
-		}
-
-		roundDays := round.Period.Days()
-		networkFee := round.NetworkFee
-
-		// -- Validator rewards  --
+		// Add validator participations to round and total aggregations
 		for _, participation := range validatorParticipations {
-			participation.reward, participation.feeDeduction, err = c.calculateReward(
-				participation.TotalActiveEffectiveBalance,
-				participation.TotalRegisteredEffectiveBalance,
-				participation.RegisteredDays,
-				roundDays,
-				dailyReward,
-				networkFee.Gwei(),
-			)
-			if err != nil {
-				return fmt.Errorf("failed to calculate validator reward: %w", err)
-			}
-
 			byValidator = append(byValidator, &ValidatorParticipationRound{
 				Round:                  round.Period,
 				ValidatorParticipation: participation,
 			})
 			if total, ok := totalByValidator[participation.PublicKey]; ok {
 				total.ActiveDays += participation.ActiveDays
+				total.RegisteredDays += participation.RegisteredDays
+				total.TotalActiveEffectiveBalance += participation.TotalActiveEffectiveBalance
+				total.TotalRegisteredEffectiveBalance += participation.TotalRegisteredEffectiveBalance
 				total.reward = new(big.Int).Add(total.reward, participation.reward)
 				total.feeDeduction = new(big.Int).Add(total.feeDeduction, participation.feeDeduction)
 			} else {
@@ -251,43 +227,8 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 			}
 		}
 
-		// -- Owner rewards  --
-		ownerAggregations := make(map[string]*OwnerParticipation)
-
-		for _, vParticipation := range validatorParticipations {
-			ownerAddr := vParticipation.OwnerAddress
-			recipientAddr := vParticipation.RecipientAddress
-
-			if existing, ok := ownerAggregations[ownerAddr]; ok {
-				// Add to existing owner
-				existing.Validators++
-				existing.ActiveDays += vParticipation.ActiveDays
-				existing.RegisteredDays += vParticipation.RegisteredDays
-				existing.TotalActiveEffectiveBalance += vParticipation.TotalActiveEffectiveBalance
-				existing.TotalRegisteredEffectiveBalance += vParticipation.TotalRegisteredEffectiveBalance
-				existing.reward = new(big.Int).Add(existing.reward, vParticipation.reward)
-				existing.feeDeduction = new(big.Int).Add(existing.feeDeduction, vParticipation.feeDeduction)
-			} else {
-				// Create new owner entry with the validator's values
-				ownerAggregations[ownerAddr] = &OwnerParticipation{
-					OwnerAddress:                    ownerAddr,
-					RecipientAddress:                recipientAddr,
-					Validators:                      1,
-					ActiveDays:                      vParticipation.ActiveDays,
-					RegisteredDays:                  vParticipation.RegisteredDays,
-					TotalActiveEffectiveBalance:     vParticipation.TotalActiveEffectiveBalance,
-					TotalRegisteredEffectiveBalance: vParticipation.TotalRegisteredEffectiveBalance,
-					reward:                          new(big.Int).Set(vParticipation.reward),
-					feeDeduction:                    new(big.Int).Set(vParticipation.feeDeduction),
-				}
-			}
-		}
-
-		// Convert map to slice and add to round results
-		ownerParticipations := make([]*OwnerParticipation, 0, len(ownerAggregations))
-		for _, participation := range ownerAggregations {
-			ownerParticipations = append(ownerParticipations, participation)
-
+		// Add owner participations to round and total aggregations
+		for _, participation := range ownerParticipations {
 			byOwner = append(byOwner, &OwnerParticipationRound{
 				Round:              round.Period,
 				OwnerParticipation: participation,
@@ -308,41 +249,8 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 			}
 		}
 
-		// -- Recipient rewards  --
-		recipientAggregations := make(map[string]*RecipientParticipation)
-
-		for _, vParticipation := range validatorParticipations {
-			recipientAddr := vParticipation.RecipientAddress
-
-			if existing, ok := recipientAggregations[recipientAddr]; ok {
-				// Add to existing recipient
-				existing.Validators++
-				existing.ActiveDays += vParticipation.ActiveDays
-				existing.RegisteredDays += vParticipation.RegisteredDays
-				existing.TotalActiveEffectiveBalance += vParticipation.TotalActiveEffectiveBalance
-				existing.TotalRegisteredEffectiveBalance += vParticipation.TotalRegisteredEffectiveBalance
-				existing.reward = new(big.Int).Add(existing.reward, vParticipation.reward)
-				existing.feeDeduction = new(big.Int).Add(existing.feeDeduction, vParticipation.feeDeduction)
-			} else {
-				// Create new recipient entry with the validator's values
-				recipientAggregations[recipientAddr] = &RecipientParticipation{
-					RecipientAddress:                recipientAddr,
-					Validators:                      1,
-					ActiveDays:                      vParticipation.ActiveDays,
-					RegisteredDays:                  vParticipation.RegisteredDays,
-					TotalActiveEffectiveBalance:     vParticipation.TotalActiveEffectiveBalance,
-					TotalRegisteredEffectiveBalance: vParticipation.TotalRegisteredEffectiveBalance,
-					reward:                          new(big.Int).Set(vParticipation.reward),
-					feeDeduction:                    new(big.Int).Set(vParticipation.feeDeduction),
-				}
-			}
-		}
-
-		// Convert map to slice and add to round results
-		recipientParticipations := make([]*RecipientParticipation, 0, len(recipientAggregations))
-		for _, participation := range recipientAggregations {
-			recipientParticipations = append(recipientParticipations, participation)
-
+		// Add recipient participations to round and total aggregations
+		for _, participation := range recipientParticipations {
 			byRecipient = append(byRecipient, &RecipientParticipationRound{
 				Round:                  round.Period,
 				RecipientParticipation: participation,
@@ -362,6 +270,7 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 			}
 		}
 
+		// Normalize all participations
 		for _, p := range validatorParticipations {
 			p.Normalize()
 		}
@@ -374,7 +283,6 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 
 		// Add network fee address entries if configured
 		if mechanics.NetworkFeeAddress != (rewards.ExecutionAddress{}) {
-			// Calculate total fee deductions
 			totalFees := big.NewInt(0)
 			totalActiveDays := 0
 			totalRegisteredDays := 0
@@ -387,12 +295,9 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 				}
 			}
 
-			// Only add network fee entries if total fees > 0
 			if totalFees.Sign() > 0 {
-				// Convert ExecutionAddress to string format (hex without 0x)
 				networkFeeAddr := mechanics.NetworkFeeAddress.String()
 
-				// Add to owner participations
 				ownerFeeEntry := &OwnerParticipation{
 					OwnerAddress:                    networkFeeAddr,
 					RecipientAddress:                networkFeeAddr,
@@ -407,7 +312,6 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 				ownerFeeEntry.Normalize()
 				ownerParticipations = append(ownerParticipations, ownerFeeEntry)
 
-				// Add to recipient participations
 				recipientFeeEntry := &RecipientParticipation{
 					RecipientAddress:                networkFeeAddr,
 					Validators:                      0,
@@ -421,7 +325,6 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 				recipientFeeEntry.Normalize()
 				recipientParticipations = append(recipientParticipations, recipientFeeEntry)
 
-				// Add to round-level aggregations
 				byOwner = append(byOwner, &OwnerParticipationRound{
 					Round:              round.Period,
 					OwnerParticipation: ownerFeeEntry,
@@ -432,7 +335,6 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 					RecipientParticipation: recipientFeeEntry,
 				})
 
-				// Add to totals
 				if existing, ok := totalByOwner[networkFeeAddr]; ok {
 					existing.ActiveDays += totalActiveDays
 					existing.reward = new(big.Int).Add(existing.reward, totalFees)
@@ -469,17 +371,17 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 		}
 
 		// Export CSVs
-		dir := filepath.Join(dir, round.Period.String())
-		if err := os.Mkdir(dir, 0755); err != nil {
-			return fmt.Errorf("failed to create directory %q: %w", dir, err)
+		roundDir := filepath.Join(dir, round.Period.String())
+		if err := os.Mkdir(roundDir, 0755); err != nil {
+			return fmt.Errorf("failed to create directory %q: %w", roundDir, err)
 		}
-		if err := exportCSV(validatorParticipations, filepath.Join(dir, "by-validator.csv")); err != nil {
+		if err := exportCSV(validatorParticipations, filepath.Join(roundDir, "by-validator.csv")); err != nil {
 			return fmt.Errorf("failed to export validator rewards: %w", err)
 		}
-		if err := exportCSV(ownerParticipations, filepath.Join(dir, "by-owner.csv")); err != nil {
+		if err := exportCSV(ownerParticipations, filepath.Join(roundDir, "by-owner.csv")); err != nil {
 			return fmt.Errorf("failed to export owner rewards: %w", err)
 		}
-		if err := exportCSV(recipientParticipations, filepath.Join(dir, "by-recipient.csv")); err != nil {
+		if err := exportCSV(recipientParticipations, filepath.Join(roundDir, "by-recipient.csv")); err != nil {
 			return fmt.Errorf("failed to export recipient rewards: %w", err)
 		}
 
@@ -488,7 +390,7 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 		for _, participation := range totalByRecipient {
 			totalRewards["0x"+participation.RecipientAddress] = participation.reward.String()
 		}
-		f, err := os.Create(filepath.Join(dir, "cumulative.json"))
+		f, err := os.Create(filepath.Join(roundDir, "cumulative.json"))
 		if err != nil {
 			return fmt.Errorf("failed to create cumulative.json: %w", err)
 		}
@@ -499,12 +401,27 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 			return fmt.Errorf("failed to encode total rewards: %w", err)
 		}
 
+		totalEffectiveBalanceGwei := c.calculateTotalEffectiveBalance(validatorParticipations)
+		tier, err := c.plan.Tier(round.Period, totalEffectiveBalanceGwei)
+		if err != nil {
+			return fmt.Errorf("failed to get tier: %w", err)
+		}
+		var dailyReward, monthlyReward, annualReward *big.Int
+		if time.Time(round.Period).Before(time.Time(legacyBeforePeriod)) {
+			dailyReward, monthlyReward, annualReward, err = c.plan.ValidatorRewardsLegacy(round.Period, totalEffectiveBalanceGwei)
+		} else {
+			dailyReward, monthlyReward, annualReward, err = c.plan.ValidatorRewards(round.Period, totalEffectiveBalanceGwei)
+		}
+		if err != nil {
+			return fmt.Errorf("failed to get rewards: %w", err)
+		}
+
 		logger.Info(
 			"Exported rewards for round",
 			zap.String("period", round.Period.String()),
 			zap.Int64("total_effective_balance", totalEffectiveBalanceGwei/Gwei),
 			zap.Int64("tier", tier.MaxEffectiveBalance),
-			zap.String("network_fee", networkFee.String()),
+			zap.String("network_fee", round.NetworkFee.String()),
 			zap.String("daily_reward", precise.NewETH(nil).SetWei(dailyReward).String()),
 			zap.String("monthly_reward", precise.NewETH(nil).SetWei(monthlyReward).String()),
 			zap.String("annual_reward", precise.NewETH(nil).SetWei(annualReward).String()),
@@ -554,6 +471,251 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 	}
 
 	return nil
+}
+
+// processRoundLegacy handles reward calculation for periods before 2025-08
+// It uses SQL-aggregated data to preserve backward compatibility with published merkle trees
+func (c *CalcCmd) processRoundLegacy(
+	ctx context.Context,
+	logger *zap.Logger,
+	round rewards.Round,
+	mechanics *rewards.Mechanics,
+	ownerRedirectsSupport, validatorRedirectsSupport bool,
+) (*roundResults, error) {
+	validatorParticipations, err := c.validatorParticipations(ctx, round.Period, mechanics, ownerRedirectsSupport, validatorRedirectsSupport)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get validator participations: %w", err)
+	}
+
+	ownerParticipations, err := c.ownerParticipations(ctx, round.Period, mechanics, ownerRedirectsSupport, validatorRedirectsSupport)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get owner participations: %w", err)
+	}
+
+	recipientParticipations, err := c.recipientParticipations(ctx, round.Period, mechanics, ownerRedirectsSupport, validatorRedirectsSupport)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get recipient participations: %w", err)
+	}
+
+	totalEffectiveBalanceGwei := c.calculateTotalEffectiveBalance(validatorParticipations)
+
+	tier, err := c.plan.Tier(round.Period, totalEffectiveBalanceGwei)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tier: %w", err)
+	}
+
+	dailyReward, _, _, err := c.plan.ValidatorRewardsLegacy(round.Period, totalEffectiveBalanceGwei)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get rewards: %w", err)
+	}
+
+	roundDays := round.Period.Days()
+	networkFee := round.NetworkFee
+
+	for _, participation := range validatorParticipations {
+		participation.reward, participation.feeDeduction, err = c.calculateReward(
+			participation.TotalActiveEffectiveBalance,
+			participation.TotalRegisteredEffectiveBalance,
+			participation.RegisteredDays,
+			roundDays,
+			dailyReward,
+			networkFee.Gwei(),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to calculate validator reward: %w", err)
+		}
+	}
+
+	for _, participation := range ownerParticipations {
+		participation.reward, participation.feeDeduction, err = c.calculateReward(
+			participation.TotalActiveEffectiveBalance,
+			participation.TotalRegisteredEffectiveBalance,
+			participation.RegisteredDays,
+			roundDays,
+			dailyReward,
+			networkFee.Gwei(),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to calculate owner reward: %w", err)
+		}
+	}
+
+	for _, participation := range recipientParticipations {
+		participation.reward, participation.feeDeduction, err = c.calculateReward(
+			participation.TotalActiveEffectiveBalance,
+			participation.TotalRegisteredEffectiveBalance,
+			participation.RegisteredDays,
+			roundDays,
+			dailyReward,
+			networkFee.Gwei(),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to calculate recipient reward: %w", err)
+		}
+	}
+
+	logger.Info("Calculated rewards for round",
+		zap.String("period", round.Period.String()),
+		zap.Int64("tier", tier.MaxEffectiveBalance),
+		zap.String("network_fee", networkFee.String()),
+	)
+
+	return &roundResults{
+		validatorParticipations: validatorParticipations,
+		ownerParticipations:     ownerParticipations,
+		recipientParticipations: recipientParticipations,
+	}, nil
+}
+
+// processRound handles reward calculation for periods from 2025-08 onwards
+// It calculates fees per validator before aggregation for correct fee handling
+func (c *CalcCmd) processRound(
+	ctx context.Context,
+	logger *zap.Logger,
+	round rewards.Round,
+	mechanics *rewards.Mechanics,
+	ownerRedirectsSupport, validatorRedirectsSupport bool,
+) (*roundResults, error) {
+	validatorParticipations, err := c.validatorParticipations(ctx, round.Period, mechanics, ownerRedirectsSupport, validatorRedirectsSupport)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get validator participations: %w", err)
+	}
+
+	totalEffectiveBalanceGwei := c.calculateTotalEffectiveBalance(validatorParticipations)
+
+	tier, err := c.plan.Tier(round.Period, totalEffectiveBalanceGwei)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tier: %w", err)
+	}
+
+	dailyReward, _, _, err := c.plan.ValidatorRewards(round.Period, totalEffectiveBalanceGwei)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get rewards: %w", err)
+	}
+
+	roundDays := round.Period.Days()
+	networkFee := round.NetworkFee
+
+	for _, participation := range validatorParticipations {
+		participation.reward, participation.feeDeduction, err = c.calculateReward(
+			participation.TotalActiveEffectiveBalance,
+			participation.TotalRegisteredEffectiveBalance,
+			participation.RegisteredDays,
+			roundDays,
+			dailyReward,
+			networkFee.Gwei(),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to calculate validator reward: %w", err)
+		}
+	}
+
+	ownerParticipations := c.aggregateByOwner(validatorParticipations)
+	recipientParticipations := c.aggregateByRecipient(validatorParticipations)
+
+	logger.Info("Calculated rewards for round",
+		zap.String("period", round.Period.String()),
+		zap.Int64("tier", tier.MaxEffectiveBalance),
+		zap.String("network_fee", networkFee.String()),
+	)
+
+	return &roundResults{
+		validatorParticipations: validatorParticipations,
+		ownerParticipations:     ownerParticipations,
+		recipientParticipations: recipientParticipations,
+	}, nil
+}
+
+// calculateTotalEffectiveBalance calculates the total effective balance across all validators
+func (c *CalcCmd) calculateTotalEffectiveBalance(validators []*ValidatorParticipation) int64 {
+	var totalEffectiveBalanceGwei int64
+	for _, v := range validators {
+		if v.ActiveDays == 0 {
+			continue
+		}
+		totalEffectiveBalanceGwei += v.TotalActiveEffectiveBalance / int64(v.ActiveDays)
+	}
+	return totalEffectiveBalanceGwei
+}
+
+// aggregateByOwner aggregates validator participations by owner address
+func (c *CalcCmd) aggregateByOwner(validators []*ValidatorParticipation) []*OwnerParticipation {
+	aggregations := make(map[string]*OwnerParticipation)
+
+	for _, v := range validators {
+		ownerAddr := v.OwnerAddress
+
+		if existing, ok := aggregations[ownerAddr]; ok {
+			existing.Validators++
+			existing.ActiveDays += v.ActiveDays
+			existing.RegisteredDays += v.RegisteredDays
+			existing.TotalActiveEffectiveBalance += v.TotalActiveEffectiveBalance
+			existing.TotalRegisteredEffectiveBalance += v.TotalRegisteredEffectiveBalance
+			existing.reward = new(big.Int).Add(existing.reward, v.reward)
+			existing.feeDeduction = new(big.Int).Add(existing.feeDeduction, v.feeDeduction)
+		} else {
+			aggregations[ownerAddr] = &OwnerParticipation{
+				OwnerAddress:                    ownerAddr,
+				RecipientAddress:                v.RecipientAddress,
+				Validators:                      1,
+				ActiveDays:                      v.ActiveDays,
+				RegisteredDays:                  v.RegisteredDays,
+				TotalActiveEffectiveBalance:     v.TotalActiveEffectiveBalance,
+				TotalRegisteredEffectiveBalance: v.TotalRegisteredEffectiveBalance,
+				reward:                          new(big.Int).Set(v.reward),
+				feeDeduction:                    new(big.Int).Set(v.feeDeduction),
+			}
+		}
+	}
+
+	result := make([]*OwnerParticipation, 0, len(aggregations))
+	for _, participation := range aggregations {
+		result = append(result, participation)
+	}
+	return result
+}
+
+// aggregateByRecipient aggregates validator participations by recipient address
+func (c *CalcCmd) aggregateByRecipient(validators []*ValidatorParticipation) []*RecipientParticipation {
+	aggregations := make(map[string]*RecipientParticipation)
+
+	for _, v := range validators {
+		recipientAddr := v.RecipientAddress
+
+		if existing, ok := aggregations[recipientAddr]; ok {
+			existing.Validators++
+			existing.ActiveDays += v.ActiveDays
+			existing.RegisteredDays += v.RegisteredDays
+			existing.TotalActiveEffectiveBalance += v.TotalActiveEffectiveBalance
+			existing.TotalRegisteredEffectiveBalance += v.TotalRegisteredEffectiveBalance
+			existing.reward = new(big.Int).Add(existing.reward, v.reward)
+			existing.feeDeduction = new(big.Int).Add(existing.feeDeduction, v.feeDeduction)
+		} else {
+			aggregations[recipientAddr] = &RecipientParticipation{
+				RecipientAddress:                recipientAddr,
+				Validators:                      1,
+				ActiveDays:                      v.ActiveDays,
+				RegisteredDays:                  v.RegisteredDays,
+				TotalActiveEffectiveBalance:     v.TotalActiveEffectiveBalance,
+				TotalRegisteredEffectiveBalance: v.TotalRegisteredEffectiveBalance,
+				reward:                          new(big.Int).Set(v.reward),
+				feeDeduction:                    new(big.Int).Set(v.feeDeduction),
+			}
+		}
+	}
+
+	result := make([]*RecipientParticipation, 0, len(aggregations))
+	for _, participation := range aggregations {
+		result = append(result, participation)
+	}
+	return result
+}
+
+// roundResults contains all the calculated participations for a round
+type roundResults struct {
+	validatorParticipations []*ValidatorParticipation
+	ownerParticipations     []*OwnerParticipation
+	recipientParticipations []*RecipientParticipation
 }
 
 func (c *CalcCmd) calculateReward(
@@ -680,6 +842,26 @@ type OwnerParticipationRound struct {
 	*OwnerParticipation
 }
 
+func (c *CalcCmd) ownerParticipations(
+	ctx context.Context,
+	period rewards.Period,
+	mechanics *rewards.Mechanics,
+	ownerRedirectsSupport, validatorRedirectsSupport bool,
+) ([]*OwnerParticipation, error) {
+	var participations []*OwnerParticipation
+	return participations, queries.Raw(
+		"SELECT * FROM participations_by_owner($1, $2, $3, $4, $5, $6, $7, $8)",
+		c.PerformanceProvider,
+		mechanics.Criteria.MinAttestationsPerDay,
+		mechanics.Criteria.MinDecidedsPerDay,
+		time.Time(period),
+		nil,
+		ownerRedirectsSupport,
+		validatorRedirectsSupport,
+		mechanics.PectraSupport,
+	).Bind(ctx, c.db, &participations)
+}
+
 type RecipientParticipation struct {
 	RecipientAddress                string
 	Validators                      int
@@ -703,6 +885,26 @@ func (p *RecipientParticipation) Normalize() {
 type RecipientParticipationRound struct {
 	Round rewards.Period
 	*RecipientParticipation
+}
+
+func (c *CalcCmd) recipientParticipations(
+	ctx context.Context,
+	period rewards.Period,
+	mechanics *rewards.Mechanics,
+	ownerRedirectsSupport, validatorRedirectsSupport bool,
+) ([]*RecipientParticipation, error) {
+	var participations []*RecipientParticipation
+	return participations, queries.Raw(
+		"SELECT * FROM participations_by_recipient($1, $2, $3, $4, $5, $6, $7, $8)",
+		c.PerformanceProvider,
+		mechanics.Criteria.MinAttestationsPerDay,
+		mechanics.Criteria.MinDecidedsPerDay,
+		time.Time(period),
+		nil,
+		ownerRedirectsSupport,
+		validatorRedirectsSupport,
+		mechanics.PectraSupport,
+	).Bind(ctx, c.db, &participations)
 }
 
 func (c *CalcCmd) prepareRedirections(

--- a/cmd/ssv-rewards/calc.go
+++ b/cmd/ssv-rewards/calc.go
@@ -177,8 +177,8 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 		totalByRecipient = map[string]*RecipientParticipation{}
 	)
 
-	// Use legacy calculations before this period (defaults to 2025-08)
-	legacyBeforePeriod := c.plan.GetLegacyBeforePeriod()
+	// Get the legacy calculation cutoff (defaults to 2025-08)
+	legacyCalculationCutoff := c.plan.GetLegacyCalculationCutoff()
 
 	for _, round := range completeRounds {
 		mechanics, err := c.plan.Mechanics.At(round.Period)
@@ -195,7 +195,7 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 		}
 
 		var results *roundResults
-		if time.Time(round.Period).Before(time.Time(legacyBeforePeriod)) {
+		if time.Time(round.Period).Before(time.Time(legacyCalculationCutoff)) {
 			results, err = c.processRoundLegacy(ctx, logger, round, mechanics, ownerRedirectsSupport, validatorRedirectsSupport)
 		} else {
 			results, err = c.processRound(ctx, logger, round, mechanics, ownerRedirectsSupport, validatorRedirectsSupport)
@@ -410,7 +410,7 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 			return fmt.Errorf("failed to get tier: %w", err)
 		}
 		var dailyReward, monthlyReward, annualReward *big.Int
-		if time.Time(round.Period).Before(time.Time(legacyBeforePeriod)) {
+		if time.Time(round.Period).Before(time.Time(legacyCalculationCutoff)) {
 			dailyReward, monthlyReward, annualReward, err = c.plan.ValidatorRewardsLegacy(round.Period, totalEffectiveBalanceGwei)
 		} else {
 			dailyReward, monthlyReward, annualReward, err = c.plan.ValidatorRewards(round.Period, totalEffectiveBalanceGwei)

--- a/cmd/ssv-rewards/calc.go
+++ b/cmd/ssv-rewards/calc.go
@@ -519,7 +519,7 @@ func (c *CalcCmd) processRoundLegacy(
 			participation.RegisteredDays,
 			roundDays,
 			dailyReward,
-			networkFee.Gwei(),
+			networkFee.Wei(),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to calculate validator reward: %w", err)
@@ -533,7 +533,7 @@ func (c *CalcCmd) processRoundLegacy(
 			participation.RegisteredDays,
 			roundDays,
 			dailyReward,
-			networkFee.Gwei(),
+			networkFee.Wei(),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to calculate owner reward: %w", err)
@@ -547,7 +547,7 @@ func (c *CalcCmd) processRoundLegacy(
 			participation.RegisteredDays,
 			roundDays,
 			dailyReward,
-			networkFee.Gwei(),
+			networkFee.Wei(),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to calculate recipient reward: %w", err)
@@ -604,7 +604,7 @@ func (c *CalcCmd) processRound(
 			participation.RegisteredDays,
 			roundDays,
 			dailyReward,
-			networkFee.Gwei(),
+			networkFee.Wei(),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to calculate validator reward: %w", err)

--- a/cmd/ssv-rewards/calc.go
+++ b/cmd/ssv-rewards/calc.go
@@ -421,7 +421,7 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 			zap.String("period", round.Period.String()),
 			zap.Int64("total_effective_balance", totalEffectiveBalanceGwei/Gwei),
 			zap.Int64("tier", tier.MaxEffectiveBalance),
-			zap.String("network_fee", round.NetworkFee.String()),
+			zap.String("network_fee_gwei", round.NetworkFee.Gwei().String()),
 			zap.String("daily_reward", precise.NewETH(nil).SetWei(dailyReward).String()),
 			zap.String("monthly_reward", precise.NewETH(nil).SetWei(monthlyReward).String()),
 			zap.String("annual_reward", precise.NewETH(nil).SetWei(annualReward).String()),
@@ -557,7 +557,7 @@ func (c *CalcCmd) processRoundLegacy(
 	logger.Info("Calculated rewards for round",
 		zap.String("period", round.Period.String()),
 		zap.Int64("tier", tier.MaxEffectiveBalance),
-		zap.String("network_fee", networkFee.String()),
+		zap.String("network_fee_gwei", networkFee.Gwei().String()),
 	)
 
 	return &roundResults{
@@ -617,7 +617,7 @@ func (c *CalcCmd) processRound(
 	logger.Info("Calculated rewards for round",
 		zap.String("period", round.Period.String()),
 		zap.Int64("tier", tier.MaxEffectiveBalance),
-		zap.String("network_fee", networkFee.String()),
+		zap.String("network_fee_gwei", networkFee.Gwei().String()),
 	)
 
 	return &roundResults{

--- a/cmd/ssv-rewards/calc.go
+++ b/cmd/ssv-rewards/calc.go
@@ -196,14 +196,6 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 		if err != nil {
 			return fmt.Errorf("failed to get validator participations: %w", err)
 		}
-		ownerParticipations, err := c.ownerParticipations(ctx, round.Period, mechanics, ownerRedirectsSupport, validatorRedirectsSupport)
-		if err != nil {
-			return fmt.Errorf("failed to get owner participations: %w", err)
-		}
-		recipientParticipations, err := c.recipientParticipations(ctx, round.Period, mechanics, ownerRedirectsSupport, validatorRedirectsSupport)
-		if err != nil {
-			return fmt.Errorf("failed to get recipient participations: %w", err)
-		}
 
 		// Calculate appropriate tier and rewards.
 		var totalEffectiveBalanceGwei int64
@@ -252,6 +244,7 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 			if total, ok := totalByValidator[participation.PublicKey]; ok {
 				total.ActiveDays += participation.ActiveDays
 				total.reward = new(big.Int).Add(total.reward, participation.reward)
+				total.feeDeduction = new(big.Int).Add(total.feeDeduction, participation.feeDeduction)
 			} else {
 				cpy := *participation
 				totalByValidator[participation.PublicKey] = &cpy
@@ -259,18 +252,41 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 		}
 
 		// -- Owner rewards  --
-		for _, participation := range ownerParticipations {
-			participation.reward, participation.feeDeduction, err = c.calculateReward(
-				participation.TotalActiveEffectiveBalance,
-				participation.TotalRegisteredEffectiveBalance,
-				participation.RegisteredDays,
-				roundDays,
-				dailyReward,
-				networkFee.Gwei(),
-			)
-			if err != nil {
-				return fmt.Errorf("failed to calculate owner reward: %w", err)
+		ownerAggregations := make(map[string]*OwnerParticipation)
+
+		for _, vParticipation := range validatorParticipations {
+			ownerAddr := vParticipation.OwnerAddress
+			recipientAddr := vParticipation.RecipientAddress
+
+			if existing, ok := ownerAggregations[ownerAddr]; ok {
+				// Add to existing owner
+				existing.Validators++
+				existing.ActiveDays += vParticipation.ActiveDays
+				existing.RegisteredDays += vParticipation.RegisteredDays
+				existing.TotalActiveEffectiveBalance += vParticipation.TotalActiveEffectiveBalance
+				existing.TotalRegisteredEffectiveBalance += vParticipation.TotalRegisteredEffectiveBalance
+				existing.reward = new(big.Int).Add(existing.reward, vParticipation.reward)
+				existing.feeDeduction = new(big.Int).Add(existing.feeDeduction, vParticipation.feeDeduction)
+			} else {
+				// Create new owner entry with the validator's values
+				ownerAggregations[ownerAddr] = &OwnerParticipation{
+					OwnerAddress:                    ownerAddr,
+					RecipientAddress:                recipientAddr,
+					Validators:                      1,
+					ActiveDays:                      vParticipation.ActiveDays,
+					RegisteredDays:                  vParticipation.RegisteredDays,
+					TotalActiveEffectiveBalance:     vParticipation.TotalActiveEffectiveBalance,
+					TotalRegisteredEffectiveBalance: vParticipation.TotalRegisteredEffectiveBalance,
+					reward:                          new(big.Int).Set(vParticipation.reward),
+					feeDeduction:                    new(big.Int).Set(vParticipation.feeDeduction),
+				}
 			}
+		}
+
+		// Convert map to slice and add to round results
+		ownerParticipations := make([]*OwnerParticipation, 0, len(ownerAggregations))
+		for _, participation := range ownerAggregations {
+			ownerParticipations = append(ownerParticipations, participation)
 
 			byOwner = append(byOwner, &OwnerParticipationRound{
 				Round:              round.Period,
@@ -280,7 +296,12 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 			key := participation.OwnerAddress
 			if total, ok := totalByOwner[key]; ok {
 				total.ActiveDays += participation.ActiveDays
+				total.RegisteredDays += participation.RegisteredDays
+				total.Validators += participation.Validators
+				total.TotalActiveEffectiveBalance += participation.TotalActiveEffectiveBalance
+				total.TotalRegisteredEffectiveBalance += participation.TotalRegisteredEffectiveBalance
 				total.reward = new(big.Int).Add(total.reward, participation.reward)
+				total.feeDeduction = new(big.Int).Add(total.feeDeduction, participation.feeDeduction)
 			} else {
 				cpy := *participation
 				totalByOwner[key] = &cpy
@@ -288,18 +309,39 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 		}
 
 		// -- Recipient rewards  --
-		for _, participation := range recipientParticipations {
-			participation.reward, participation.feeDeduction, err = c.calculateReward(
-				participation.TotalActiveEffectiveBalance,
-				participation.TotalRegisteredEffectiveBalance,
-				participation.RegisteredDays,
-				roundDays,
-				dailyReward,
-				networkFee.Gwei(),
-			)
-			if err != nil {
-				return fmt.Errorf("failed to calculate recipient reward: %w", err)
+		recipientAggregations := make(map[string]*RecipientParticipation)
+
+		for _, vParticipation := range validatorParticipations {
+			recipientAddr := vParticipation.RecipientAddress
+
+			if existing, ok := recipientAggregations[recipientAddr]; ok {
+				// Add to existing recipient
+				existing.Validators++
+				existing.ActiveDays += vParticipation.ActiveDays
+				existing.RegisteredDays += vParticipation.RegisteredDays
+				existing.TotalActiveEffectiveBalance += vParticipation.TotalActiveEffectiveBalance
+				existing.TotalRegisteredEffectiveBalance += vParticipation.TotalRegisteredEffectiveBalance
+				existing.reward = new(big.Int).Add(existing.reward, vParticipation.reward)
+				existing.feeDeduction = new(big.Int).Add(existing.feeDeduction, vParticipation.feeDeduction)
+			} else {
+				// Create new recipient entry with the validator's values
+				recipientAggregations[recipientAddr] = &RecipientParticipation{
+					RecipientAddress:                recipientAddr,
+					Validators:                      1,
+					ActiveDays:                      vParticipation.ActiveDays,
+					RegisteredDays:                  vParticipation.RegisteredDays,
+					TotalActiveEffectiveBalance:     vParticipation.TotalActiveEffectiveBalance,
+					TotalRegisteredEffectiveBalance: vParticipation.TotalRegisteredEffectiveBalance,
+					reward:                          new(big.Int).Set(vParticipation.reward),
+					feeDeduction:                    new(big.Int).Set(vParticipation.feeDeduction),
+				}
 			}
+		}
+
+		// Convert map to slice and add to round results
+		recipientParticipations := make([]*RecipientParticipation, 0, len(recipientAggregations))
+		for _, participation := range recipientAggregations {
+			recipientParticipations = append(recipientParticipations, participation)
 
 			byRecipient = append(byRecipient, &RecipientParticipationRound{
 				Round:                  round.Period,
@@ -308,7 +350,12 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 
 			if total, ok := totalByRecipient[participation.RecipientAddress]; ok {
 				total.ActiveDays += participation.ActiveDays
+				total.RegisteredDays += participation.RegisteredDays
+				total.Validators += participation.Validators
+				total.TotalActiveEffectiveBalance += participation.TotalActiveEffectiveBalance
+				total.TotalRegisteredEffectiveBalance += participation.TotalRegisteredEffectiveBalance
 				total.reward = new(big.Int).Add(total.reward, participation.reward)
+				total.feeDeduction = new(big.Int).Add(total.feeDeduction, participation.feeDeduction)
 			} else {
 				cpy := *participation
 				totalByRecipient[participation.RecipientAddress] = &cpy
@@ -633,26 +680,6 @@ type OwnerParticipationRound struct {
 	*OwnerParticipation
 }
 
-func (c *CalcCmd) ownerParticipations(
-	ctx context.Context,
-	period rewards.Period,
-	mechanics *rewards.Mechanics,
-	ownerRedirectsSupport, validatorRedirectsSupport bool,
-) ([]*OwnerParticipation, error) {
-	var participations []*OwnerParticipation
-	return participations, queries.Raw(
-		"SELECT * FROM participations_by_owner($1, $2, $3, $4, $5, $6, $7, $8)",
-		c.PerformanceProvider,
-		mechanics.Criteria.MinAttestationsPerDay,
-		mechanics.Criteria.MinDecidedsPerDay,
-		time.Time(period),
-		nil,
-		ownerRedirectsSupport,
-		validatorRedirectsSupport,
-		mechanics.PectraSupport,
-	).Bind(ctx, c.db, &participations)
-}
-
 type RecipientParticipation struct {
 	RecipientAddress                string
 	Validators                      int
@@ -676,26 +703,6 @@ func (p *RecipientParticipation) Normalize() {
 type RecipientParticipationRound struct {
 	Round rewards.Period
 	*RecipientParticipation
-}
-
-func (c *CalcCmd) recipientParticipations(
-	ctx context.Context,
-	period rewards.Period,
-	mechanics *rewards.Mechanics,
-	ownerRedirectsSupport, validatorRedirectsSupport bool,
-) ([]*RecipientParticipation, error) {
-	var participations []*RecipientParticipation
-	return participations, queries.Raw(
-		"SELECT * FROM participations_by_recipient($1, $2, $3, $4, $5, $6, $7, $8)",
-		c.PerformanceProvider,
-		mechanics.Criteria.MinAttestationsPerDay,
-		mechanics.Criteria.MinDecidedsPerDay,
-		time.Time(period),
-		nil,
-		ownerRedirectsSupport,
-		validatorRedirectsSupport,
-		mechanics.PectraSupport,
-	).Bind(ctx, c.db, &participations)
 }
 
 func (c *CalcCmd) prepareRedirections(

--- a/cmd/ssv-rewards/calc.go
+++ b/cmd/ssv-rewards/calc.go
@@ -519,7 +519,7 @@ func (c *CalcCmd) processRoundLegacy(
 			participation.RegisteredDays,
 			roundDays,
 			dailyReward,
-			networkFee.Wei(),
+			networkFee.Gwei(),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to calculate validator reward: %w", err)
@@ -533,7 +533,7 @@ func (c *CalcCmd) processRoundLegacy(
 			participation.RegisteredDays,
 			roundDays,
 			dailyReward,
-			networkFee.Wei(),
+			networkFee.Gwei(),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to calculate owner reward: %w", err)
@@ -547,7 +547,7 @@ func (c *CalcCmd) processRoundLegacy(
 			participation.RegisteredDays,
 			roundDays,
 			dailyReward,
-			networkFee.Wei(),
+			networkFee.Gwei(),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to calculate recipient reward: %w", err)

--- a/cmd/ssv-rewards/calc.go
+++ b/cmd/ssv-rewards/calc.go
@@ -638,14 +638,22 @@ func (c *CalcCmd) calculateTotalEffectiveBalance(validators []*ValidatorParticip
 	return totalEffectiveBalanceGwei
 }
 
-// aggregateByOwner aggregates validator participations by owner address
+// aggregateByOwner aggregates validator participations by owner and recipient address
 func (c *CalcCmd) aggregateByOwner(validators []*ValidatorParticipation) []*OwnerParticipation {
-	aggregations := make(map[string]*OwnerParticipation)
+	// Use composite key to match SQL GROUP BY behavior
+	type ownerRecipientKey struct {
+		owner     string
+		recipient string
+	}
+	aggregations := make(map[ownerRecipientKey]*OwnerParticipation)
 
 	for _, v := range validators {
-		ownerAddr := v.OwnerAddress
+		key := ownerRecipientKey{
+			owner:     v.OwnerAddress,
+			recipient: v.RecipientAddress,
+		}
 
-		if existing, ok := aggregations[ownerAddr]; ok {
+		if existing, ok := aggregations[key]; ok {
 			existing.Validators++
 			existing.ActiveDays += v.ActiveDays
 			existing.RegisteredDays += v.RegisteredDays
@@ -654,8 +662,8 @@ func (c *CalcCmd) aggregateByOwner(validators []*ValidatorParticipation) []*Owne
 			existing.reward = new(big.Int).Add(existing.reward, v.reward)
 			existing.feeDeduction = new(big.Int).Add(existing.feeDeduction, v.feeDeduction)
 		} else {
-			aggregations[ownerAddr] = &OwnerParticipation{
-				OwnerAddress:                    ownerAddr,
+			aggregations[key] = &OwnerParticipation{
+				OwnerAddress:                    v.OwnerAddress,
 				RecipientAddress:                v.RecipientAddress,
 				Validators:                      1,
 				ActiveDays:                      v.ActiveDays,

--- a/cmd/ssv-rewards/calc.go
+++ b/cmd/ssv-rewards/calc.go
@@ -207,6 +207,8 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 		validatorParticipations := results.validatorParticipations
 		ownerParticipations := results.ownerParticipations
 		recipientParticipations := results.recipientParticipations
+		totalEffectiveBalanceGwei := results.totalEffectiveBalanceGwei
+		tier := results.tier
 
 		// Add validator participations to round and total aggregations
 		for _, participation := range validatorParticipations {
@@ -404,16 +406,11 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 			return fmt.Errorf("failed to close cumulative.json: %w", err)
 		}
 
-		totalEffectiveBalanceGwei := c.calculateTotalEffectiveBalance(validatorParticipations)
-		tier, err := c.plan.Tier(round.Period, totalEffectiveBalanceGwei)
-		if err != nil {
-			return fmt.Errorf("failed to get tier: %w", err)
-		}
 		var dailyReward, monthlyReward, annualReward *big.Int
 		if time.Time(round.Period).Before(time.Time(legacyCalculationCutoff)) {
-			dailyReward, monthlyReward, annualReward, err = c.plan.ValidatorRewardsLegacy(round.Period, totalEffectiveBalanceGwei)
+			dailyReward, monthlyReward, annualReward, err = c.plan.ValidatorRewardsLegacy(round.Period, tier)
 		} else {
-			dailyReward, monthlyReward, annualReward, err = c.plan.ValidatorRewards(round.Period, totalEffectiveBalanceGwei)
+			dailyReward, monthlyReward, annualReward, err = c.plan.ValidatorRewards(round.Period, tier)
 		}
 		if err != nil {
 			return fmt.Errorf("failed to get rewards: %w", err)
@@ -507,7 +504,7 @@ func (c *CalcCmd) processRoundLegacy(
 		return nil, fmt.Errorf("failed to get tier: %w", err)
 	}
 
-	dailyReward, _, _, err := c.plan.ValidatorRewardsLegacy(round.Period, totalEffectiveBalanceGwei)
+	dailyReward, _, _, err := c.plan.ValidatorRewardsLegacy(round.Period, tier)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get rewards: %w", err)
 	}
@@ -564,9 +561,11 @@ func (c *CalcCmd) processRoundLegacy(
 	)
 
 	return &roundResults{
-		validatorParticipations: validatorParticipations,
-		ownerParticipations:     ownerParticipations,
-		recipientParticipations: recipientParticipations,
+		validatorParticipations:   validatorParticipations,
+		ownerParticipations:       ownerParticipations,
+		recipientParticipations:   recipientParticipations,
+		totalEffectiveBalanceGwei: totalEffectiveBalanceGwei,
+		tier:                      tier,
 	}, nil
 }
 
@@ -585,13 +584,12 @@ func (c *CalcCmd) processRound(
 	}
 
 	totalEffectiveBalanceGwei := c.calculateTotalEffectiveBalance(validatorParticipations)
-
 	tier, err := c.plan.Tier(round.Period, totalEffectiveBalanceGwei)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get tier: %w", err)
 	}
 
-	dailyReward, _, _, err := c.plan.ValidatorRewards(round.Period, totalEffectiveBalanceGwei)
+	dailyReward, _, _, err := c.plan.ValidatorRewards(round.Period, tier)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get rewards: %w", err)
 	}
@@ -623,9 +621,11 @@ func (c *CalcCmd) processRound(
 	)
 
 	return &roundResults{
-		validatorParticipations: validatorParticipations,
-		ownerParticipations:     ownerParticipations,
-		recipientParticipations: recipientParticipations,
+		validatorParticipations:   validatorParticipations,
+		ownerParticipations:       ownerParticipations,
+		recipientParticipations:   recipientParticipations,
+		totalEffectiveBalanceGwei: totalEffectiveBalanceGwei,
+		tier:                      tier,
 	}, nil
 }
 
@@ -724,9 +724,11 @@ func (c *CalcCmd) aggregateByRecipient(validators []*ValidatorParticipation) []*
 
 // roundResults contains all the calculated participations for a round
 type roundResults struct {
-	validatorParticipations []*ValidatorParticipation
-	ownerParticipations     []*OwnerParticipation
-	recipientParticipations []*RecipientParticipation
+	validatorParticipations   []*ValidatorParticipation
+	ownerParticipations       []*OwnerParticipation
+	recipientParticipations   []*RecipientParticipation
+	totalEffectiveBalanceGwei int64
+	tier                      *rewards.Tier
 }
 
 func (c *CalcCmd) calculateReward(

--- a/cmd/ssv-rewards/calc.go
+++ b/cmd/ssv-rewards/calc.go
@@ -394,11 +394,14 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 		if err != nil {
 			return fmt.Errorf("failed to create cumulative.json: %w", err)
 		}
-		defer f.Close()
 		enc := json.NewEncoder(f)
 		enc.SetIndent("", "  ")
 		if err := enc.Encode(totalRewards); err != nil {
+			f.Close() // Close before returning error
 			return fmt.Errorf("failed to encode total rewards: %w", err)
+		}
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("failed to close cumulative.json: %w", err)
 		}
 
 		totalEffectiveBalanceGwei := c.calculateTotalEffectiveBalance(validatorParticipations)

--- a/cmd/ssv-rewards/calc.go
+++ b/cmd/ssv-rewards/calc.go
@@ -473,7 +473,7 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 	return nil
 }
 
-// processRoundLegacy handles reward calculation for periods before 2025-08
+// processRoundLegacy handles reward calculation for periods before the legacy cutoff
 // It uses SQL-aggregated data to preserve backward compatibility with published merkle trees
 func (c *CalcCmd) processRoundLegacy(
 	ctx context.Context,
@@ -567,7 +567,7 @@ func (c *CalcCmd) processRoundLegacy(
 	}, nil
 }
 
-// processRound handles reward calculation for periods from 2025-08 onwards
+// processRound handles reward calculation for periods from the legacy cutoff onwards
 // It calculates fees per validator before aggregation for correct fee handling
 func (c *CalcCmd) processRound(
 	ctx context.Context,

--- a/cmd/ssv-rewards/calc.go
+++ b/cmd/ssv-rewards/calc.go
@@ -421,7 +421,7 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 			zap.String("period", round.Period.String()),
 			zap.Int64("total_effective_balance", totalEffectiveBalanceGwei/Gwei),
 			zap.Int64("tier", tier.MaxEffectiveBalance),
-			zap.String("network_fee_gwei", round.NetworkFee.Gwei().String()),
+			zap.String("network_fee", round.NetworkFee.String()),
 			zap.String("daily_reward", precise.NewETH(nil).SetWei(dailyReward).String()),
 			zap.String("monthly_reward", precise.NewETH(nil).SetWei(monthlyReward).String()),
 			zap.String("annual_reward", precise.NewETH(nil).SetWei(annualReward).String()),
@@ -519,7 +519,7 @@ func (c *CalcCmd) processRoundLegacy(
 			participation.RegisteredDays,
 			roundDays,
 			dailyReward,
-			networkFee.Gwei(),
+			networkFee.Wei(),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to calculate validator reward: %w", err)
@@ -533,7 +533,7 @@ func (c *CalcCmd) processRoundLegacy(
 			participation.RegisteredDays,
 			roundDays,
 			dailyReward,
-			networkFee.Gwei(),
+			networkFee.Wei(),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to calculate owner reward: %w", err)
@@ -547,7 +547,7 @@ func (c *CalcCmd) processRoundLegacy(
 			participation.RegisteredDays,
 			roundDays,
 			dailyReward,
-			networkFee.Gwei(),
+			networkFee.Wei(),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to calculate recipient reward: %w", err)
@@ -557,7 +557,7 @@ func (c *CalcCmd) processRoundLegacy(
 	logger.Info("Calculated rewards for round",
 		zap.String("period", round.Period.String()),
 		zap.Int64("tier", tier.MaxEffectiveBalance),
-		zap.String("network_fee_gwei", networkFee.Gwei().String()),
+		zap.String("network_fee", networkFee.String()),
 	)
 
 	return &roundResults{
@@ -617,7 +617,7 @@ func (c *CalcCmd) processRound(
 	logger.Info("Calculated rewards for round",
 		zap.String("period", round.Period.String()),
 		zap.Int64("tier", tier.MaxEffectiveBalance),
-		zap.String("network_fee_gwei", networkFee.Gwei().String()),
+		zap.String("network_fee", networkFee.String()),
 	)
 
 	return &roundResults{

--- a/pkg/rewards/plan.go
+++ b/pkg/rewards/plan.go
@@ -28,10 +28,10 @@ type Plan struct {
 	// LegacyBeforePeriod defines the cutoff for using legacy reward calculation methods.
 	// Periods before this date use:
 	//   - SQL-aggregated data (causing fee calculation issues for multi-validator recipients)
-	//   - Daily rewards that vary by month length (monthly= annual/12 monthly/days_in_month)
+	//   - Daily rewards that vary by month length (monthly = annual/12, then daily = monthly/days_in_month)
 	// Periods from this date onwards use:
 	//   - Per-validator fee calculation before aggregation (correct for multi-validator recipients)
-	//   - Constant daily rewards (annual/365)
+	//   - Constant daily rewards (daily = annual/365, then monthly = daily * days_in_month)
 	// Default: 2025-08 (to preserve merkle roots for already published periods)
 	LegacyBeforePeriod *Period `yaml:"legacy_before_period,omitempty"`
 }
@@ -138,7 +138,7 @@ func (p *Plan) validate() error {
 }
 
 // ValidatorRewardsLegacy calculates rewards with the original bug where daily rewards
-// vary by month length. Used for periods before 2025-08 to preserve merkle roots.
+// vary by month length. Used for periods before the legacy cutoff to preserve merkle roots.
 func (p *Plan) ValidatorRewardsLegacy(
 	period Period,
 	totalEffectiveBalanceGwei int64,
@@ -169,7 +169,7 @@ func (p *Plan) ValidatorRewardsLegacy(
 }
 
 // ValidatorRewards calculates rewards with correct daily rate (annual/365).
-// Used for periods from 2025-08 onwards.
+// Used for periods from the legacy cutoff onwards.
 func (p *Plan) ValidatorRewards(
 	period Period,
 	totalEffectiveBalanceGwei int64,

--- a/pkg/rewards/plan.go
+++ b/pkg/rewards/plan.go
@@ -134,7 +134,7 @@ func (p *Plan) validate() error {
 			return fmt.Errorf("duplicate round: %s", p.Rounds[i].Period)
 		}
 	}
-	
+
 	return nil
 }
 
@@ -142,13 +142,8 @@ func (p *Plan) validate() error {
 // vary by month length. Used for periods before the legacy cutoff to preserve merkle roots.
 func (p *Plan) ValidatorRewardsLegacy(
 	period Period,
-	totalEffectiveBalanceGwei int64,
+	tier *Tier,
 ) (daily, monthly, annual *big.Int, err error) {
-	tier, err := p.Tier(period, totalEffectiveBalanceGwei)
-	if err != nil {
-		err = fmt.Errorf("failed to determine tier: %w", err)
-		return
-	}
 	for _, round := range p.Rounds {
 		if round.Period == period {
 			// (validatorETHBalance * round.ETHAPR) / round.SSVETH * tier.APRBoost
@@ -173,13 +168,8 @@ func (p *Plan) ValidatorRewardsLegacy(
 // Used for periods from the legacy cutoff onwards.
 func (p *Plan) ValidatorRewards(
 	period Period,
-	totalEffectiveBalanceGwei int64,
+	tier *Tier,
 ) (daily, monthly, annual *big.Int, err error) {
-	tier, err := p.Tier(period, totalEffectiveBalanceGwei)
-	if err != nil {
-		err = fmt.Errorf("failed to determine tier: %w", err)
-		return
-	}
 	for _, round := range p.Rounds {
 		if round.Period == period {
 			// (validatorETHBalance * round.ETHAPR) / round.SSVETH * tier.APRBoost

--- a/pkg/rewards/plan.go
+++ b/pkg/rewards/plan.go
@@ -25,7 +25,7 @@ type Plan struct {
 	Mechanics MechanicsList `yaml:"mechanics"`
 	Rounds    Rounds        `yaml:"rounds"`
 
-	// LegacyBeforePeriod defines the cutoff for using legacy reward calculation methods.
+	// LegacyCalculationCutoff defines the cutoff for using legacy reward calculation methods.
 	// Periods before this date use:
 	//   - SQL-aggregated data (causing fee calculation issues for multi-validator recipients)
 	//   - Daily rewards that vary by month length (monthly = annual/12, then daily = monthly/days_in_month)
@@ -33,7 +33,7 @@ type Plan struct {
 	//   - Per-validator fee calculation before aggregation (correct for multi-validator recipients)
 	//   - Constant daily rewards (daily = annual/365, then monthly = daily * days_in_month)
 	// Default: 2025-08 (to preserve merkle roots for already published periods)
-	LegacyBeforePeriod *Period `yaml:"legacy_before_period,omitempty"`
+	LegacyCalculationCutoff *Period `yaml:"legacy_calculation_cutoff,omitempty"`
 }
 
 // ParsePlan parses the given YAML document into a Plan.
@@ -48,13 +48,13 @@ func ParsePlan(data []byte) (*Plan, error) {
 	return &plan, nil
 }
 
-// GetLegacyBeforePeriod returns the period before which legacy calculations are used.
-// If not configured, returns the default of 2025-08 (legacy used before 2025-08).
-func (p *Plan) GetLegacyBeforePeriod() Period {
-	if p.LegacyBeforePeriod != nil {
-		return *p.LegacyBeforePeriod
+// GetLegacyCalculationCutoff returns the cutoff period for legacy calculations.
+// If not configured, returns the default of 2025-08.
+func (p *Plan) GetLegacyCalculationCutoff() Period {
+	if p.LegacyCalculationCutoff != nil {
+		return *p.LegacyCalculationCutoff
 	}
-	// Default to 2025-08 if not configured (legacy used before this period)
+	// Default to 2025-08 if not configured
 	return NewPeriod(2025, 8)
 }
 
@@ -134,6 +134,7 @@ func (p *Plan) validate() error {
 			return fmt.Errorf("duplicate round: %s", p.Rounds[i].Period)
 		}
 	}
+	
 	return nil
 }
 

--- a/pkg/rewards/plan.go
+++ b/pkg/rewards/plan.go
@@ -127,7 +127,7 @@ func (p *Plan) validate() error {
 	}
 	for i := 1; i < len(p.Rounds); i++ {
 		round := p.Rounds[i-1]
-		if round.NetworkFee != nil && round.NetworkFee.Gwei().Sign() < 0 {
+		if round.NetworkFee != nil && round.NetworkFee.Wei().Sign() < 0 {
 			return fmt.Errorf("network_fee cannot be negative in round %s", round.Period)
 		}
 		if p.Rounds[i-1].Period == p.Rounds[i].Period {

--- a/pkg/rewards/plan.go
+++ b/pkg/rewards/plan.go
@@ -24,6 +24,16 @@ type Plan struct {
 	Version   int           `yaml:"version"`
 	Mechanics MechanicsList `yaml:"mechanics"`
 	Rounds    Rounds        `yaml:"rounds"`
+
+	// LegacyBeforePeriod defines the cutoff for using legacy reward calculation methods.
+	// Periods before this date use:
+	//   - SQL-aggregated data (causing fee calculation issues for multi-validator recipients)
+	//   - Daily rewards that vary by month length (monthly= annual/12 monthly/days_in_month)
+	// Periods from this date onwards use:
+	//   - Per-validator fee calculation before aggregation (correct for multi-validator recipients)
+	//   - Constant daily rewards (annual/365)
+	// Default: 2025-08 (to preserve merkle roots for already published periods)
+	LegacyBeforePeriod *Period `yaml:"legacy_before_period,omitempty"`
 }
 
 // ParsePlan parses the given YAML document into a Plan.
@@ -36,6 +46,16 @@ func ParsePlan(data []byte) (*Plan, error) {
 		return nil, err
 	}
 	return &plan, nil
+}
+
+// GetLegacyBeforePeriod returns the period before which legacy calculations are used.
+// If not configured, returns the default of 2025-08 (legacy used before 2025-08).
+func (p *Plan) GetLegacyBeforePeriod() Period {
+	if p.LegacyBeforePeriod != nil {
+		return *p.LegacyBeforePeriod
+	}
+	// Default to 2025-08 if not configured (legacy used before this period)
+	return NewPeriod(2025, 8)
 }
 
 func (p *Plan) validate() error {
@@ -117,6 +137,39 @@ func (p *Plan) validate() error {
 	return nil
 }
 
+// ValidatorRewardsLegacy calculates rewards with the original bug where daily rewards
+// vary by month length. Used for periods before 2025-08 to preserve merkle roots.
+func (p *Plan) ValidatorRewardsLegacy(
+	period Period,
+	totalEffectiveBalanceGwei int64,
+) (daily, monthly, annual *big.Int, err error) {
+	tier, err := p.Tier(period, totalEffectiveBalanceGwei)
+	if err != nil {
+		err = fmt.Errorf("failed to determine tier: %w", err)
+		return
+	}
+	for _, round := range p.Rounds {
+		if round.Period == period {
+			// (validatorETHBalance * round.ETHAPR) / round.SSVETH * tier.APRBoost
+			annualETH := precise.NewETH(nil).Mul(validatorETHBalance, round.ETHAPR)
+			annualETH.Quo(annualETH, round.SSVETH)
+			annualETH.Mul(annualETH, tier.APRBoost)
+			annual = annualETH.Wei()
+
+			monthlyETH := precise.NewETH(nil).Quo(annualETH, precise.NewETH64(12))
+			monthly = monthlyETH.Wei()
+
+			dailyETH := precise.NewETH(nil).Quo(monthlyETH, precise.NewETH64(float64(period.Days())))
+			daily = dailyETH.Wei()
+			return
+		}
+	}
+	err = errors.New("period not found")
+	return
+}
+
+// ValidatorRewards calculates rewards with correct daily rate (annual/365).
+// Used for periods from 2025-08 onwards.
 func (p *Plan) ValidatorRewards(
 	period Period,
 	totalEffectiveBalanceGwei int64,
@@ -134,14 +187,11 @@ func (p *Plan) ValidatorRewards(
 			annualETH.Mul(annualETH, tier.APRBoost)
 			annual = annualETH.Wei()
 
-			// annual / 12
-			monthlyETH := precise.NewETH(nil).Quo(annualETH, precise.NewETH64(12))
-			monthly = monthlyETH.Wei()
-
-			// monthly / period.Days()
-			dailyETH := precise.NewETH(nil).
-				Quo(monthlyETH, precise.NewETH64(float64(period.Days())))
+			dailyETH := precise.NewETH(nil).Quo(annualETH, precise.NewETH64(365))
 			daily = dailyETH.Wei()
+
+			monthlyETH := precise.NewETH(nil).Mul(dailyETH, precise.NewETH64(float64(period.Days())))
+			monthly = monthlyETH.Wei()
 			return
 		}
 	}

--- a/pkg/rewards/plan_test.go
+++ b/pkg/rewards/plan_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestParseYAML(t *testing.T) {
 	input := `
+legacy_calculation_cutoff: 2025-08
 mechanics:
   - since: 2023-07
     criteria:
@@ -55,6 +56,7 @@ rounds:
     ssv_eth: 
 `
 	expected := Plan{
+		LegacyCalculationCutoff: func() *Period { p := NewPeriod(2025, 8); return &p }(),
 		Mechanics: MechanicsList{
 			{
 				Since: NewPeriod(2023, time.July),

--- a/rewards.example.yaml
+++ b/rewards.example.yaml
@@ -81,4 +81,4 @@ rounds:
   - period: 2023-10
     eth_apr: 0.049
     ssv_eth: 0.0092352941
-    network_fee: 100_000_000  # Network fee in SSV Gwei
+    network_fee: 0.1  # Network fee in SSV


### PR DESCRIPTION
## Problem
  Two critical calculation bugs were affecting reward distributions:

  1. **Fee Calculation Bug**: Fee deductions were calculated incorrectly for recipients with multiple validators. The by-recipient.csv showed different fee amounts than the sum of individual
  validator fees in by-validator.csv.

  2. **Daily Reward Variation Bug**: Daily rewards incorrectly varied by month length. The calculation used monthly = annual/12, then daily = monthly/days_in_month, causing validators to receive
  different daily rates depending on the month (e.g., February vs. March).

  ## Root Cause
  1. **Fee Issue**: The fee formula contains non-linear operations (max, min) making `Fee(A+B) ≠ Fee(A) + Fee(B)`. When aggregating validator data before calculating fees (as done in SQL), these
  operations produced incorrect results for multi-validator recipients.

  2. **Daily Reward Issue**: Using month-based division caused daily rewards to fluctuate unnecessarily. The correct approach is to use a constant daily rate (annual/365) then multiply by days in
  the month.

  ## Solution
  Implemented a dual-calculation approach with a configurable cutoff period to maintain backward compatibility:

  ### For periods BEFORE the cutoff (default: 2025-08):
  - Uses legacy calculation method with SQL-aggregated data (preserves existing merkle trees)
  - Maintains the original bugs:
    - Fees calculated on aggregated data (incorrect for multi-validator recipients)
    - Daily rewards vary by month length (monthly = annual/12, then daily = monthly/days_in_month)

  ### For periods FROM the cutoff onwards:
  - Calculates fees at the validator level BEFORE aggregation (fixes fee bug)
  - Uses constant daily rate (daily = annual/365, then monthly = daily * days_in_month) (fixes daily reward bug)
  - Uses new aggregation methods (`aggregateByOwner`, `aggregateByRecipient`) in Go

  ## Changes
  - Added `LegacyCalculationCutoff` field to Plan configuration (yaml: `legacy_calculation_cutoff`)
  - Split calculation logic into `processRoundLegacy` and `processRound` methods
  - Added `ValidatorRewardsLegacy` method for backward-compatible reward calculation (with bugs)
  - Updated `ValidatorRewards` method with corrected calculations (both fixes applied)
  - Retained SQL aggregation functions for backward compatibility (used only in legacy path)
  - Added helper methods: `calculateTotalEffectiveBalance`, `aggregateByOwner`, `aggregateByRecipient`

  ## Backward Compatibility
  - All periods before the cutoff date will produce identical results to maintain merkle tree validity
  - The cutoff is configurable via `legacy_calculation_cutoff` in rewards.yaml
  - Default cutoff is 2025-08 to preserve all currently published merkle trees

  ## Impact
  From the cutoff period onwards:
  - Recipients with multiple validators will see corrected (lower) fee deductions
  - Daily rewards will be consistent regardless of month length (28, 29, 30, or 31 days)

