### PR TITLE
Lower the fetched block batch size to fit EL limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ Edit `rewards.yaml` to match [the specifications](https://docs.google.com/docume
 ```yaml
 version: 2
 
+# ETH-fee cluster migration support (optional).
+# staking_upgrade:
+#   block: 22345678
+#   log_index: 42
+
 mechanics:
   - since: 2023-07
     criteria:
@@ -164,12 +169,18 @@ This produces the following documents under the `./rewards` directory:
 ├── 📄 by-recipient.csv        # Reward for each recipient for each round
 ├── 📄 total-by-owner.csv      # Total reward for each owner
 ├── 📄 total-by-validator.csv  # Total reward for each validator
+├── 📄 exclusions.csv          # Excluded validator-days with reasons
+├── 📄 *-eth.csv               # ETH tree variants (only when migrations exist)
 └── 📂 <year>-<month>
     ├── 📄 by-owner.csv        # Total reward for each owner for that round
     ├── 📄 by-validator.csv    # Total reward for each validator for that round
     ├── 📄 by-recipient.csv    # Total reward for each recipient for that round
-    └── 📄 cumulative.json     # Cumulative reward for each owner until and including that round
+    ├── 📄 cumulative.json     # Cumulative SSV-tree reward for each recipient
+    ├── 📄 *-eth.csv           # ETH tree CSVs (only when migrations exist)
+    └── 📄 cumulative-eth.json # Cumulative ETH-tree reward (only when migrations exist)
 ```
+
+When `staking_upgrade` is configured and validators have migrated to ETH-fee clusters, the calc step produces two sets of outputs: SSV tree files (existing filenames, with fee deduction) and ETH tree files (`-eth` suffix, no fee deduction). Each tree has its own cumulative JSON for merkleization.
 
 - `recipient` is the address that eventually receives the reward, which is either the owner address, or if the owner is redirecting the reward, the address specified in `owner_redirects` or `owner_redirects_file`.
 

--- a/cmd/ssv-rewards/calc.go
+++ b/cmd/ssv-rewards/calc.go
@@ -387,7 +387,11 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 			if err := exportCSV(ethRPs, filepath.Join(roundDir, "by-recipient-eth.csv")); err != nil {
 				return fmt.Errorf("export ETH recipient rewards: %w", err)
 			}
+		}
 
+		// Write cumulative ETH rewards for every round that has accumulated
+		// totals, even when the current round has no new ETH participations.
+		if len(ethTotalByRecipient) > 0 {
 			ethTotalRewards := map[string]string{}
 			for _, p := range ethTotalByRecipient {
 				ethTotalRewards["0x"+p.RecipientAddress] = p.reward.String()

--- a/cmd/ssv-rewards/calc.go
+++ b/cmd/ssv-rewards/calc.go
@@ -176,9 +176,18 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 		totalByValidator = map[string]*ValidatorParticipation{}
 		totalByOwner     = map[string]*OwnerParticipation{}
 		totalByRecipient = map[string]*RecipientParticipation{}
+
+		// ETH tree accumulators (used when StakingUpgrade is configured).
+		ethByValidator      []*ValidatorParticipationRound
+		ethByOwner          []*OwnerParticipationRound
+		ethByRecipient      []*RecipientParticipationRound
+		ethTotalByValidator = map[string]*ValidatorParticipation{}
+		ethTotalByOwner     = map[string]*OwnerParticipation{}
+		ethTotalByRecipient = map[string]*RecipientParticipation{}
 	)
 
 	legacyCalculationCutoff := c.plan.LegacyCalculationCutoff
+	hasMigrationSupport := c.plan.StakingUpgrade != nil
 
 	for _, round := range completeRounds {
 		mechanics, err := c.plan.Mechanics.At(round.Period)
@@ -195,8 +204,11 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 		}
 
 		var results *roundResults
+		var ethResults *roundResults
 		if round.Period.Before(legacyCalculationCutoff) {
 			results, err = c.processRoundLegacy(ctx, round, mechanics, ownerRedirectsSupport, validatorRedirectsSupport)
+		} else if hasMigrationSupport {
+			results, ethResults, err = c.processRoundWithMigration(ctx, round, mechanics, ownerRedirectsSupport, validatorRedirectsSupport)
 		} else {
 			results, err = c.processRound(ctx, round, mechanics, ownerRedirectsSupport, validatorRedirectsSupport)
 		}
@@ -208,67 +220,9 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 		ownerParticipations := results.ownerParticipations
 		recipientParticipations := results.recipientParticipations
 
-		// Add validator participations to round and total aggregations
-		for _, participation := range validatorParticipations {
-			byValidator = append(byValidator, &ValidatorParticipationRound{
-				Round:                  round.Period,
-				ValidatorParticipation: participation,
-			})
-			if total, ok := totalByValidator[participation.PublicKey]; ok {
-				total.ActiveDays += participation.ActiveDays
-				total.RegisteredDays += participation.RegisteredDays
-				total.TotalActiveEffectiveBalance += participation.TotalActiveEffectiveBalance
-				total.TotalRegisteredEffectiveBalance += participation.TotalRegisteredEffectiveBalance
-				total.reward = new(big.Int).Add(total.reward, participation.reward)
-				total.feeDeduction = new(big.Int).Add(total.feeDeduction, participation.feeDeduction)
-			} else {
-				cpy := *participation
-				totalByValidator[participation.PublicKey] = &cpy
-			}
-		}
-
-		// Add owner participations to round and total aggregations
-		for _, participation := range ownerParticipations {
-			byOwner = append(byOwner, &OwnerParticipationRound{
-				Round:              round.Period,
-				OwnerParticipation: participation,
-			})
-
-			key := participation.OwnerAddress
-			if total, ok := totalByOwner[key]; ok {
-				total.ActiveDays += participation.ActiveDays
-				total.RegisteredDays += participation.RegisteredDays
-				total.Validators += participation.Validators
-				total.TotalActiveEffectiveBalance += participation.TotalActiveEffectiveBalance
-				total.TotalRegisteredEffectiveBalance += participation.TotalRegisteredEffectiveBalance
-				total.reward = new(big.Int).Add(total.reward, participation.reward)
-				total.feeDeduction = new(big.Int).Add(total.feeDeduction, participation.feeDeduction)
-			} else {
-				cpy := *participation
-				totalByOwner[key] = &cpy
-			}
-		}
-
-		// Add recipient participations to round and total aggregations
-		for _, participation := range recipientParticipations {
-			byRecipient = append(byRecipient, &RecipientParticipationRound{
-				Round:                  round.Period,
-				RecipientParticipation: participation,
-			})
-
-			if total, ok := totalByRecipient[participation.RecipientAddress]; ok {
-				total.ActiveDays += participation.ActiveDays
-				total.RegisteredDays += participation.RegisteredDays
-				total.Validators += participation.Validators
-				total.TotalActiveEffectiveBalance += participation.TotalActiveEffectiveBalance
-				total.TotalRegisteredEffectiveBalance += participation.TotalRegisteredEffectiveBalance
-				total.reward = new(big.Int).Add(total.reward, participation.reward)
-				total.feeDeduction = new(big.Int).Add(total.feeDeduction, participation.feeDeduction)
-			} else {
-				cpy := *participation
-				totalByRecipient[participation.RecipientAddress] = &cpy
-			}
-		}
+		accumulateValidators(validatorParticipations, round.Period, &byValidator, totalByValidator)
+		accumulateOwners(ownerParticipations, round.Period, &byOwner, totalByOwner)
+		accumulateRecipients(recipientParticipations, round.Period, &byRecipient, totalByRecipient)
 
 		// Normalize all participations
 		for _, p := range validatorParticipations {
@@ -404,6 +358,55 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 			return fmt.Errorf("failed to close cumulative.json: %w", err)
 		}
 
+		// ETH tree: accumulate, normalize, and export (no network fee).
+		if ethResults != nil && len(ethResults.validatorParticipations) > 0 {
+			ethVPs := ethResults.validatorParticipations
+			ethOPs := ethResults.ownerParticipations
+			ethRPs := ethResults.recipientParticipations
+
+			accumulateValidators(ethVPs, round.Period, &ethByValidator, ethTotalByValidator)
+			accumulateOwners(ethOPs, round.Period, &ethByOwner, ethTotalByOwner)
+			accumulateRecipients(ethRPs, round.Period, &ethByRecipient, ethTotalByRecipient)
+
+			for _, p := range ethVPs {
+				p.Normalize()
+			}
+			for _, p := range ethOPs {
+				p.Normalize()
+			}
+			for _, p := range ethRPs {
+				p.Normalize()
+			}
+
+			if err := exportCSV(ethVPs, filepath.Join(roundDir, "by-validator-eth.csv")); err != nil {
+				return fmt.Errorf("export ETH validator rewards: %w", err)
+			}
+			if err := exportCSV(ethOPs, filepath.Join(roundDir, "by-owner-eth.csv")); err != nil {
+				return fmt.Errorf("export ETH owner rewards: %w", err)
+			}
+			if err := exportCSV(ethRPs, filepath.Join(roundDir, "by-recipient-eth.csv")); err != nil {
+				return fmt.Errorf("export ETH recipient rewards: %w", err)
+			}
+
+			ethTotalRewards := map[string]string{}
+			for _, p := range ethTotalByRecipient {
+				ethTotalRewards["0x"+p.RecipientAddress] = p.reward.String()
+			}
+			ef, err := os.Create(filepath.Join(roundDir, "cumulative-eth.json"))
+			if err != nil {
+				return fmt.Errorf("create cumulative-eth.json: %w", err)
+			}
+			eEnc := json.NewEncoder(ef)
+			eEnc.SetIndent("", "  ")
+			if err := eEnc.Encode(ethTotalRewards); err != nil {
+				ef.Close()
+				return fmt.Errorf("encode ETH total rewards: %w", err)
+			}
+			if err := ef.Close(); err != nil {
+				return fmt.Errorf("close cumulative-eth.json: %w", err)
+			}
+		}
+
 		var dailyReward, monthlyReward, annualReward *big.Int
 		if round.Period.Before(legacyCalculationCutoff) {
 			dailyReward, monthlyReward, annualReward, err = c.plan.ValidatorRewardsLegacy(round.Period, results.tier)
@@ -425,11 +428,19 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 		}
 
 		if round.InflationCap != nil {
+			// For two-tree rounds, compute combined original/final for scaling ratio.
+			combinedOriginal := new(big.Int).Set(results.originalRewards.Wei())
+			combinedFinal := new(big.Int).Set(results.finalRewards.Wei())
+			if ethResults != nil && len(ethResults.validatorParticipations) > 0 {
+				combinedOriginal.Add(combinedOriginal, ethResults.originalRewards.Wei())
+				combinedFinal.Add(combinedFinal, ethResults.finalRewards.Wei())
+			}
+
 			scalingRatio := 1.0
-			if results.originalRewards.Wei().Sign() > 0 {
+			if combinedOriginal.Sign() > 0 {
 				scalingRatioFloat := new(big.Float).Quo(
-					new(big.Float).SetInt(results.finalRewards.Wei()),
-					new(big.Float).SetInt(results.originalRewards.Wei()),
+					new(big.Float).SetInt(combinedFinal),
+					new(big.Float).SetInt(combinedOriginal),
 				)
 				scalingRatio, _ = scalingRatioFloat.Float64()
 			}
@@ -437,8 +448,17 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 			logFields = append(logFields,
 				zap.String("inflation_cap", round.InflationCap.Display()),
 				zap.Float64("scaling_ratio", scalingRatio),
-				zap.String("original_rewards", results.originalRewards.Display()),
-				zap.String("final_rewards", results.finalRewards.Display()),
+				zap.String("original_rewards", precise.NewETH(nil).SetWei(combinedOriginal).Display()),
+				zap.String("final_rewards", precise.NewETH(nil).SetWei(combinedFinal).Display()),
+			)
+		}
+
+		if ethResults != nil && len(ethResults.validatorParticipations) > 0 {
+			logFields = append(logFields,
+				zap.String("ssv_final_rewards", results.finalRewards.Display()),
+				zap.String("eth_final_rewards", ethResults.finalRewards.Display()),
+				zap.Int("ssv_validators", len(results.validatorParticipations)),
+				zap.Int("eth_validators", len(ethResults.validatorParticipations)),
 			)
 		}
 
@@ -475,16 +495,58 @@ func (c *CalcCmd) run(ctx context.Context, logger *zap.Logger, dir string) error
 		return fmt.Errorf("failed to export total recipient rewards: %w", err)
 	}
 
+	// Export ETH tree cross-round totals (only when entries exist).
+	if len(ethTotalByRecipient) > 0 {
+		for _, v := range ethTotalByValidator {
+			v.Normalize()
+		}
+		for _, o := range ethTotalByOwner {
+			o.Normalize()
+		}
+		for _, r := range ethTotalByRecipient {
+			r.Normalize()
+		}
+
+		if err := exportCSV(ethByValidator, filepath.Join(dir, "by-validator-eth.csv")); err != nil {
+			return fmt.Errorf("export ETH total validator rewards: %w", err)
+		}
+		if err := exportCSV(ethByOwner, filepath.Join(dir, "by-owner-eth.csv")); err != nil {
+			return fmt.Errorf("export ETH total owner rewards: %w", err)
+		}
+		if err := exportCSV(ethByRecipient, filepath.Join(dir, "by-recipient-eth.csv")); err != nil {
+			return fmt.Errorf("export ETH total recipient rewards: %w", err)
+		}
+		if err := exportCSV(maps.Values(ethTotalByValidator), filepath.Join(dir, "total-by-validator-eth.csv")); err != nil {
+			return fmt.Errorf("export ETH total validator rewards: %w", err)
+		}
+		if err := exportCSV(maps.Values(ethTotalByOwner), filepath.Join(dir, "total-by-owner-eth.csv")); err != nil {
+			return fmt.Errorf("export ETH total owner rewards: %w", err)
+		}
+		if err := exportCSV(maps.Values(ethTotalByRecipient), filepath.Join(dir, "total-by-recipient-eth.csv")); err != nil {
+			return fmt.Errorf("export ETH total recipient rewards: %w", err)
+		}
+	}
+
 	// Export exclusions.
-	exclusions, err := c.exclusions(
-		ctx,
-		completeRounds,
-	)
+	exclusions, err := c.exclusions(ctx, completeRounds, "ssv")
 	if err != nil {
 		return fmt.Errorf("failed to get exclusions: %w", err)
 	}
 	if err := exportCSV(exclusions, filepath.Join(dir, "exclusions.csv")); err != nil {
 		return fmt.Errorf("failed to export exclusions: %w", err)
+	}
+
+	// Export ETH tree exclusions (only when migration support is configured).
+	if c.plan.StakingUpgrade != nil {
+		ethExclusions, err := c.exclusions(ctx, completeRounds, "eth")
+		if err != nil {
+			return fmt.Errorf("failed to get ETH exclusions: %w", err)
+		}
+		if len(ethExclusions) > 0 {
+			if err := exportCSV(ethExclusions, filepath.Join(dir, "exclusions-eth.csv")); err != nil {
+				return fmt.Errorf("failed to export ETH exclusions: %w", err)
+			}
+		}
 	}
 
 	return nil
@@ -498,17 +560,17 @@ func (c *CalcCmd) processRoundLegacy(
 	mechanics *rewards.Mechanics,
 	ownerRedirectsSupport, validatorRedirectsSupport bool,
 ) (*roundResults, error) {
-	validatorParticipations, err := c.validatorParticipations(ctx, round.Period, mechanics, ownerRedirectsSupport, validatorRedirectsSupport)
+	validatorParticipations, err := c.validatorParticipations(ctx, round.Period, mechanics, ownerRedirectsSupport, validatorRedirectsSupport, "ssv")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get validator participations: %w", err)
 	}
 
-	ownerParticipations, err := c.ownerParticipations(ctx, round.Period, mechanics, ownerRedirectsSupport, validatorRedirectsSupport)
+	ownerParticipations, err := c.ownerParticipations(ctx, round.Period, mechanics, ownerRedirectsSupport, validatorRedirectsSupport, "ssv")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get owner participations: %w", err)
 	}
 
-	recipientParticipations, err := c.recipientParticipations(ctx, round.Period, mechanics, ownerRedirectsSupport, validatorRedirectsSupport)
+	recipientParticipations, err := c.recipientParticipations(ctx, round.Period, mechanics, ownerRedirectsSupport, validatorRedirectsSupport, "ssv")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get recipient participations: %w", err)
 	}
@@ -601,7 +663,7 @@ func (c *CalcCmd) processRound(
 	mechanics *rewards.Mechanics,
 	ownerRedirectsSupport, validatorRedirectsSupport bool,
 ) (*roundResults, error) {
-	validatorParticipations, err := c.validatorParticipations(ctx, round.Period, mechanics, ownerRedirectsSupport, validatorRedirectsSupport)
+	validatorParticipations, err := c.validatorParticipations(ctx, round.Period, mechanics, ownerRedirectsSupport, validatorRedirectsSupport, "ssv")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get validator participations: %w", err)
 	}
@@ -688,6 +750,210 @@ func (c *CalcCmd) processRound(
 		finalRewards:            finalRewards,
 		originalRewards:         originalRewards,
 	}, nil
+}
+
+// processRoundWithMigration handles reward calculation for rounds with ETH migration support.
+// It queries both SSV and ETH validator participations, computes a combined effective balance
+// for tier selection, and applies a single shared inflation cap across both trees.
+func (c *CalcCmd) processRoundWithMigration(
+	ctx context.Context,
+	round rewards.Round,
+	mechanics *rewards.Mechanics,
+	ownerRedirectsSupport, validatorRedirectsSupport bool,
+) (ssvResults *roundResults, ethResults *roundResults, err error) {
+	ssvVPs, err := c.validatorParticipations(ctx, round.Period, mechanics, ownerRedirectsSupport, validatorRedirectsSupport, "ssv")
+	if err != nil {
+		return nil, nil, fmt.Errorf("get SSV validator participations: %w", err)
+	}
+	ethVPs, err := c.validatorParticipations(ctx, round.Period, mechanics, ownerRedirectsSupport, validatorRedirectsSupport, "eth")
+	if err != nil {
+		return nil, nil, fmt.Errorf("get ETH validator participations: %w", err)
+	}
+
+	// Combined effective balance for tier selection.
+	allVPs := make([]*ValidatorParticipation, 0, len(ssvVPs)+len(ethVPs))
+	allVPs = append(allVPs, ssvVPs...)
+	allVPs = append(allVPs, ethVPs...)
+
+	var totalEffectiveBalance *precise.ETH
+	if round.Period.Before(tierCalculationCutoff) {
+		totalEffectiveBalance = c.calculateTotalEffectiveBalanceLegacy(allVPs)
+	} else {
+		totalEffectiveBalance = c.calculateTotalEffectiveBalance(allVPs, round.Period.Days())
+	}
+	tier, err := c.plan.Tier(round.Period, totalEffectiveBalance)
+	if err != nil {
+		return nil, nil, fmt.Errorf("get tier: %w", err)
+	}
+
+	dailyReward, _, _, err := c.plan.ValidatorRewards(round.Period, tier)
+	if err != nil {
+		return nil, nil, fmt.Errorf("get rewards: %w", err)
+	}
+
+	roundDays := round.Period.Days()
+	ssvNetworkFee := round.NetworkFee.Wei()
+	ethNetworkFee := big.NewInt(0)
+
+	// First pass: compute combined base reward for inflation cap.
+	totalBaseReward := big.NewInt(0)
+	ssvOriginalWei := big.NewInt(0)
+	ethOriginalWei := big.NewInt(0)
+
+	for _, v := range ssvVPs {
+		reward, fee, err := c.calculateReward(
+			v.TotalActiveEffectiveBalance, v.TotalRegisteredEffectiveBalance,
+			v.RegisteredDays, roundDays, dailyReward, ssvNetworkFee,
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf("calculate SSV base reward: %w", err)
+		}
+		ssvOriginalWei.Add(ssvOriginalWei, reward)
+		totalBaseReward.Add(totalBaseReward, new(big.Int).Add(reward, fee))
+	}
+	for _, v := range ethVPs {
+		reward, fee, err := c.calculateReward(
+			v.TotalActiveEffectiveBalance, v.TotalRegisteredEffectiveBalance,
+			v.RegisteredDays, roundDays, dailyReward, ethNetworkFee,
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf("calculate ETH base reward: %w", err)
+		}
+		ethOriginalWei.Add(ethOriginalWei, reward)
+		totalBaseReward.Add(totalBaseReward, new(big.Int).Add(reward, fee))
+	}
+
+	// Scale daily reward if inflation cap exceeded.
+	scaledDailyReward := new(big.Int).Set(dailyReward)
+	if round.InflationCap != nil &&
+		totalBaseReward.Sign() > 0 && totalBaseReward.Cmp(round.InflationCap.Wei()) > 0 {
+		scaledDailyReward.Mul(scaledDailyReward, round.InflationCap.Wei())
+		scaledDailyReward.Div(scaledDailyReward, totalBaseReward)
+	}
+
+	// Second pass: compute final rewards with (potentially) scaled daily reward.
+	ssvFinalWei := big.NewInt(0)
+	for _, v := range ssvVPs {
+		v.reward, v.feeDeduction, err = c.calculateReward(
+			v.TotalActiveEffectiveBalance, v.TotalRegisteredEffectiveBalance,
+			v.RegisteredDays, roundDays, scaledDailyReward, ssvNetworkFee,
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf("calculate SSV final reward: %w", err)
+		}
+		ssvFinalWei.Add(ssvFinalWei, v.reward)
+	}
+
+	ethFinalWei := big.NewInt(0)
+	for _, v := range ethVPs {
+		v.reward, v.feeDeduction, err = c.calculateReward(
+			v.TotalActiveEffectiveBalance, v.TotalRegisteredEffectiveBalance,
+			v.RegisteredDays, roundDays, scaledDailyReward, ethNetworkFee,
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf("calculate ETH final reward: %w", err)
+		}
+		ethFinalWei.Add(ethFinalWei, v.reward)
+	}
+
+	ssvResults = &roundResults{
+		validatorParticipations: ssvVPs,
+		ownerParticipations:     c.aggregateByOwner(ssvVPs),
+		recipientParticipations: c.aggregateByRecipient(ssvVPs),
+		totalEffectiveBalance:   totalEffectiveBalance,
+		tier:                    tier,
+		originalRewards:         precise.NewETH(nil).SetWei(ssvOriginalWei),
+		finalRewards:            precise.NewETH(nil).SetWei(ssvFinalWei),
+	}
+	ethResults = &roundResults{
+		validatorParticipations: ethVPs,
+		ownerParticipations:     c.aggregateByOwner(ethVPs),
+		recipientParticipations: c.aggregateByRecipient(ethVPs),
+		totalEffectiveBalance:   totalEffectiveBalance,
+		tier:                    tier,
+		originalRewards:         precise.NewETH(nil).SetWei(ethOriginalWei),
+		finalRewards:            precise.NewETH(nil).SetWei(ethFinalWei),
+	}
+
+	return ssvResults, ethResults, nil
+}
+
+func accumulateValidators(
+	participations []*ValidatorParticipation,
+	period rewards.Period,
+	byRound *[]*ValidatorParticipationRound,
+	totals map[string]*ValidatorParticipation,
+) {
+	for _, p := range participations {
+		*byRound = append(*byRound, &ValidatorParticipationRound{
+			Round:                  period,
+			ValidatorParticipation: p,
+		})
+		if total, ok := totals[p.PublicKey]; ok {
+			total.ActiveDays += p.ActiveDays
+			total.RegisteredDays += p.RegisteredDays
+			total.TotalActiveEffectiveBalance += p.TotalActiveEffectiveBalance
+			total.TotalRegisteredEffectiveBalance += p.TotalRegisteredEffectiveBalance
+			total.reward = new(big.Int).Add(total.reward, p.reward)
+			total.feeDeduction = new(big.Int).Add(total.feeDeduction, p.feeDeduction)
+		} else {
+			cpy := *p
+			totals[p.PublicKey] = &cpy
+		}
+	}
+}
+
+func accumulateOwners(
+	participations []*OwnerParticipation,
+	period rewards.Period,
+	byRound *[]*OwnerParticipationRound,
+	totals map[string]*OwnerParticipation,
+) {
+	for _, p := range participations {
+		*byRound = append(*byRound, &OwnerParticipationRound{
+			Round:              period,
+			OwnerParticipation: p,
+		})
+		key := p.OwnerAddress
+		if total, ok := totals[key]; ok {
+			total.ActiveDays += p.ActiveDays
+			total.RegisteredDays += p.RegisteredDays
+			total.Validators += p.Validators
+			total.TotalActiveEffectiveBalance += p.TotalActiveEffectiveBalance
+			total.TotalRegisteredEffectiveBalance += p.TotalRegisteredEffectiveBalance
+			total.reward = new(big.Int).Add(total.reward, p.reward)
+			total.feeDeduction = new(big.Int).Add(total.feeDeduction, p.feeDeduction)
+		} else {
+			cpy := *p
+			totals[key] = &cpy
+		}
+	}
+}
+
+func accumulateRecipients(
+	participations []*RecipientParticipation,
+	period rewards.Period,
+	byRound *[]*RecipientParticipationRound,
+	totals map[string]*RecipientParticipation,
+) {
+	for _, p := range participations {
+		*byRound = append(*byRound, &RecipientParticipationRound{
+			Round:                  period,
+			RecipientParticipation: p,
+		})
+		if total, ok := totals[p.RecipientAddress]; ok {
+			total.ActiveDays += p.ActiveDays
+			total.RegisteredDays += p.RegisteredDays
+			total.Validators += p.Validators
+			total.TotalActiveEffectiveBalance += p.TotalActiveEffectiveBalance
+			total.TotalRegisteredEffectiveBalance += p.TotalRegisteredEffectiveBalance
+			total.reward = new(big.Int).Add(total.reward, p.reward)
+			total.feeDeduction = new(big.Int).Add(total.feeDeduction, p.feeDeduction)
+		} else {
+			cpy := *p
+			totals[p.RecipientAddress] = &cpy
+		}
+	}
 }
 
 // calculateTotalEffectiveBalanceLegacy calculates total EB as sum of average EB per validator.
@@ -914,10 +1180,11 @@ func (c *CalcCmd) validatorParticipations(
 	period rewards.Period,
 	mechanics *rewards.Mechanics,
 	ownerRedirectsSupport, validatorRedirectsSupport bool,
+	migrationFilter string,
 ) ([]*ValidatorParticipation, error) {
 	var participations []*ValidatorParticipation
 	return participations, queries.Raw(
-		"SELECT * FROM participations_by_validator($1, $2, $3, $4, $5, $6, $7, $8)",
+		"SELECT * FROM participations_by_validator($1, $2, $3, $4, $5, $6, $7, $8, $9)",
 		c.PerformanceProvider,
 		mechanics.Criteria.MinAttestationsPerDay,
 		mechanics.Criteria.MinDecidedsPerDay,
@@ -926,6 +1193,7 @@ func (c *CalcCmd) validatorParticipations(
 		ownerRedirectsSupport,
 		validatorRedirectsSupport,
 		mechanics.PectraSupport,
+		migrationFilter,
 	).Bind(ctx, c.db, &participations)
 }
 
@@ -966,10 +1234,11 @@ func (c *CalcCmd) ownerParticipations(
 	period rewards.Period,
 	mechanics *rewards.Mechanics,
 	ownerRedirectsSupport, validatorRedirectsSupport bool,
+	migrationFilter string,
 ) ([]*OwnerParticipation, error) {
 	var participations []*OwnerParticipation
 	return participations, queries.Raw(
-		"SELECT * FROM participations_by_owner($1, $2, $3, $4, $5, $6, $7, $8)",
+		"SELECT * FROM participations_by_owner($1, $2, $3, $4, $5, $6, $7, $8, $9)",
 		c.PerformanceProvider,
 		mechanics.Criteria.MinAttestationsPerDay,
 		mechanics.Criteria.MinDecidedsPerDay,
@@ -978,6 +1247,7 @@ func (c *CalcCmd) ownerParticipations(
 		ownerRedirectsSupport,
 		validatorRedirectsSupport,
 		mechanics.PectraSupport,
+		migrationFilter,
 	).Bind(ctx, c.db, &participations)
 }
 
@@ -1017,10 +1287,11 @@ func (c *CalcCmd) recipientParticipations(
 	period rewards.Period,
 	mechanics *rewards.Mechanics,
 	ownerRedirectsSupport, validatorRedirectsSupport bool,
+	migrationFilter string,
 ) ([]*RecipientParticipation, error) {
 	var participations []*RecipientParticipation
 	return participations, queries.Raw(
-		"SELECT * FROM participations_by_recipient($1, $2, $3, $4, $5, $6, $7, $8)",
+		"SELECT * FROM participations_by_recipient($1, $2, $3, $4, $5, $6, $7, $8, $9)",
 		c.PerformanceProvider,
 		mechanics.Criteria.MinAttestationsPerDay,
 		mechanics.Criteria.MinDecidedsPerDay,
@@ -1029,6 +1300,7 @@ func (c *CalcCmd) recipientParticipations(
 		ownerRedirectsSupport,
 		validatorRedirectsSupport,
 		mechanics.PectraSupport,
+		migrationFilter,
 	).Bind(ctx, c.db, &participations)
 }
 
@@ -1174,6 +1446,7 @@ type Exclusion struct {
 func (c *CalcCmd) exclusionsForRound(
 	ctx context.Context,
 	period rewards.Period,
+	migrationFilter string,
 ) ([]*Exclusion, error) {
 	mechanics, err := c.plan.Mechanics.At(period)
 	if err != nil {
@@ -1192,12 +1465,13 @@ func (c *CalcCmd) exclusionsForRound(
 	}
 
 	err = queries.Raw(
-		"SELECT * FROM exclusions_by_validator($1, $2, $3, $4, $5)",
+		"SELECT * FROM exclusions_by_validator($1, $2, $3, $4, $5, $6)",
 		c.PerformanceProvider,
 		mechanics.Criteria.MinAttestationsPerDay,
 		mechanics.Criteria.MinDecidedsPerDay,
 		time.Time(period),
 		time.Time(period),
+		migrationFilter,
 	).Bind(ctx, c.db, &rows)
 	if err != nil {
 		return nil, err
@@ -1222,10 +1496,11 @@ func (c *CalcCmd) exclusionsForRound(
 func (c *CalcCmd) exclusions(
 	ctx context.Context,
 	rounds []rewards.Round,
+	migrationFilter string,
 ) ([]*Exclusion, error) {
 	var exclusions []*Exclusion
 	for _, round := range rounds {
-		e, err := c.exclusionsForRound(ctx, round.Period)
+		e, err := c.exclusionsForRound(ctx, round.Period, migrationFilter)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get exclusions for round %s: %w", round.Period, err)
 		}

--- a/cmd/ssv-rewards/sync.go
+++ b/cmd/ssv-rewards/sync.go
@@ -141,6 +141,7 @@ func (c *SyncCmd) Run(
 		ctx,
 		c.ExecutionEndpoint,
 		common.HexToAddress(network.RegistryContractAddr),
+		executionclient.WithLogBatchSize(1000),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to connect to execution node: %w", err)

--- a/cmd/ssv-rewards/sync.go
+++ b/cmd/ssv-rewards/sync.go
@@ -241,6 +241,7 @@ func (c *SyncCmd) Run(
 		nodeStorage,
 		db,
 		cl,
+		plan.StakingUpgrade,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to sync validator events: %w", err)

--- a/docs/qa-eth-cluster-migration.md
+++ b/docs/qa-eth-cluster-migration.md
@@ -1,0 +1,303 @@
+# SSV Rewards — ETH Migration QA Plan
+
+## Overview
+
+Validators migrating to ETH-fee clusters receive a `migration_day` in the database. The reward calculation splits each validator's days into two independent trees:
+
+- **SSV tree**: days before `migration_day` (with network fee deduction) — existing `cumulative.json`
+- **ETH tree**: days from `migration_day` onward (no network fee) — new `cumulative-eth.json`
+
+Each tree produces separate CSV and JSON outputs and is merkleized independently.
+
+When no validators have migrated, all outputs are identical to the current release.
+
+**Output locations:**
+- Per-round files: `rewards/<period>/`
+- Total files: `rewards/`
+
+**Prerequisites:**
+- New binary built from the PR branch
+- Mainnet DB access (synced with previous release)
+- `rewards.yaml` from the latest release inputs
+
+> **Note:** All dates used in this document (`2025-09-01`, `2025-09-15`, etc.) are examples. Adjust to match the data available in your DB.
+
+---
+
+## Phase 1: Regression — No config changes
+
+**Goal:** New code produces identical outputs when no migration config is present.
+
+**Steps:**
+1. Start from an existing mainnet DB synced with the previous release binary.
+2. Run the schema migration:
+   ```sql
+   ALTER TABLE validators ADD COLUMN IF NOT EXISTS migration_day DATE;
+   ```
+3. Run `calc` with the new binary. Do **not** add `staking_upgrade` to `rewards.yaml`.
+4. Generate merkle from `rewards/<latest-round>/cumulative.json` (see [Merkle generation](#merkle-generation)).
+
+**Verify:**
+- [ ] SSV merkle root matches the latest published round.
+- [ ] No `-eth` output files are produced (`by-*-eth.csv`, `cumulative-eth.json`).
+
+> **Important:** Save the `rewards/` output directory from this phase — later phases reference it for comparison.
+
+---
+
+## Phase 2: Sync modes
+
+**Goal:** Verify different sync modes handle the `migration_day` column correctly.
+
+### 2a: Fresh sync
+
+1. Run `sync --fresh` (drops schema, recreates from scratch).
+2. Verify `migration_day` column exists without manual ALTER:
+   ```sql
+   SELECT column_name FROM information_schema.columns
+   WHERE table_name = 'validators' AND column_name = 'migration_day';
+   -- Expected: 1 row
+   ```
+3. Run `calc`.
+4. Verify: SSV merkle root matches Phase 1.
+
+### 2b: Fresh sync with keep-cache
+
+1. Run `sync --fresh --keep-cache`.
+2. Verify `.cache` directory is preserved (files still present from previous sync).
+3. Run `calc`.
+4. Verify: SSV merkle root matches Phase 1.
+
+### 2c: Incremental sync preserves migration_day
+
+This validates the `boil.Blacklist` fix — incremental sync must not wipe `migration_day`.
+
+1. Manually seed `migration_day` on a few validators:
+   ```sql
+   UPDATE validators SET migration_day = '2025-09-15'
+   WHERE public_key IN (SELECT public_key FROM validators LIMIT 3);
+   ```
+2. Run `sync` (no `--fresh`).
+3. Verify `migration_day` is preserved:
+   ```sql
+   SELECT count(*) FROM validators WHERE migration_day IS NOT NULL;
+   -- Expected: 3
+   ```
+4. Clean up:
+   ```sql
+   UPDATE validators SET migration_day = NULL WHERE migration_day IS NOT NULL;
+   ```
+
+---
+
+## Phase 3: Dual-tree — Comprehensive test
+
+**Goal:** Verify the full dual-tree behavior with one carefully chosen seeding that covers all key scenarios.
+
+### Setup
+
+Pick a round that has both `network_fee` and `inflation_cap` configured (e.g., Sep 2025). The seeding should cover:
+
+1. **Find a multi-validator owner** (for mixed-owner testing):
+   ```sql
+   SELECT owner_address, array_agg(DISTINCT vp.public_key) AS keys, count(DISTINCT vp.public_key) AS cnt
+   FROM validator_performances vp
+   WHERE vp.day >= '2025-09-01' AND vp.day < '2025-10-01' AND vp.solvent_whole_day
+   GROUP BY owner_address
+   HAVING count(DISTINCT vp.public_key) >= 4
+   LIMIT 5;
+   ```
+
+2. **Migrate half of that owner's validators** mid-month:
+   ```sql
+   UPDATE validators SET migration_day = '2025-09-15'
+   WHERE public_key IN ('...first_half...');
+   ```
+
+3. **Also migrate a few validators that have redirects** (skip if no redirects are configured in this environment):
+   ```sql
+   -- Find validators with redirects.
+   SELECT v.public_key, vr.to_address
+   FROM validators v
+   JOIN validator_redirects vr ON v.public_key = vr.public_key
+   LIMIT 5;
+
+   -- Migrate some of them.
+   UPDATE validators SET migration_day = '2025-09-15'
+   WHERE public_key IN ('...redirected_keys...');
+   ```
+
+4. Run `calc`.
+5. Generate merkles from both `cumulative.json` and `cumulative-eth.json` (see [Merkle generation](#merkle-generation)).
+
+### Verify: Basic split
+
+- [ ] ETH per-round files produced: `by-validator-eth.csv`, `by-owner-eth.csv`, `by-recipient-eth.csv`, `cumulative-eth.json`.
+- [ ] ETH total files produced: `total-by-validator-eth.csv`, `total-by-owner-eth.csv`, `total-by-recipient-eth.csv`.
+- [ ] In SSV CSVs: migrated validators show fewer `active_days` than Phase 1 (only pre-migration days).
+- [ ] In ETH CSVs: migrated validators show `active_days` from `migration_day` onward only.
+- [ ] SSV merkle root **differs** from Phase 1.
+- [ ] ETH merkle tree is valid.
+
+### Verify: Mixed owner
+
+- [ ] SSV `by-owner.csv`: the multi-validator owner has all non-migrated validators' days + pre-migration days of migrated validators.
+- [ ] ETH `by-owner-eth.csv`: same owner has only post-migration days of migrated validators.
+- [ ] Non-migrated validators do **not** appear in ETH CSVs.
+- [ ] Both `cumulative.json` and `cumulative-eth.json` contain this owner's recipient address.
+
+### Verify: Redirects
+
+- [ ] In SSV CSVs: redirected recipient receives pre-migration rewards.
+- [ ] In ETH CSVs: same redirected recipient receives post-migration rewards.
+- [ ] `cumulative-eth.json` uses the redirected address, not the original owner.
+
+### Verify: Network fee
+
+- [ ] In ETH CSVs: fee column is 0 for all rows.
+- [ ] `cumulative.json` includes the `network_fee_address` with accumulated fees.
+- [ ] `cumulative-eth.json` does **not** include the `network_fee_address`.
+
+### Verify: Inflation cap
+
+- [ ] If the round hit the cap in Phase 1: SSV total + ETH total for the round equals the Phase 1 total (cap is shared, total unchanged).
+- [ ] If the round didn't hit the cap: SSV total + ETH total equals what the uncapped combined rewards would be.
+
+### Verify: Tier selection
+
+- [ ] Calc log output shows the tier is based on the **combined** effective balance (SSV + ETH), not per-tree.
+- [ ] For a recipient appearing in both trees: the reward-per-active-day ratio is consistent between SSV and ETH CSVs (same tier was applied to both).
+
+### Verify: Multi-round behavior
+
+Ensure the migrated validators from setup have performance data in the month before and after the migration month (e.g., Aug and Oct if migrating in Sep). If not, pick additional validators that span 3 consecutive rounds.
+
+- [ ] Round before the migration month: migrated validators appear in SSV only, not in ETH CSVs.
+- [ ] Migration month: migrated validators appear in both trees (split by day).
+- [ ] Round after the migration month: migrated validators appear in ETH only, not in SSV CSVs.
+
+### Verify: Pectra effective balance
+
+- [ ] SSV `by-validator.csv`: `total_active_effective_balance` reflects only pre-migration days' balances.
+- [ ] ETH `by-validator-eth.csv`: `total_active_effective_balance` reflects only post-migration days' balances.
+
+### Verify: Exclusions
+
+- [ ] SSV `exclusions.csv`: no rows with `day >= migration_day` for migrated validators.
+- [ ] ETH `exclusions-eth.csv`: no rows with `day < migration_day` for migrated validators.
+
+---
+
+## Phase 4: Edge cases
+
+Reset before each test case:
+
+```sql
+UPDATE validators SET migration_day = NULL WHERE migration_day IS NOT NULL;
+```
+
+### 4a: First day of month
+
+Set `migration_day` = first day of a round month, run `calc`.
+
+- [ ] All days in that month go to ETH tree, none to SSV for that round.
+
+### 4b: Last day of month
+
+Set `migration_day` = last day of a round month, run `calc`.
+
+- [ ] Only the last day goes to ETH tree for that round.
+
+### 4c: Month with no round
+
+Set `migration_day` in a month that has no configured round, run `calc`.
+
+- [ ] No effect on any outputs.
+
+### 4d: Legacy rounds
+
+Set `migration_day` on validators to a date within a legacy round (before `legacy_calculation_cutoff`), run `calc`.
+
+- [ ] Legacy rounds produce no `-eth` output files.
+- [ ] Legacy round outputs are unchanged (compare against a clean run with no `migration_day` set).
+
+---
+
+## Phase 5: Sync event handling (future — when contract migrates on mainnet)
+
+> This phase cannot be tested until `ClusterMigratedToETH` events are emitted on mainnet.
+
+**Steps:**
+1. Set `staking_upgrade` in `rewards.yaml` to the actual contract migration block and log_index.
+2. Run `sync --fresh --keep-cache` against mainnet after the contract migration.
+3. Run `calc`.
+
+**Verify:**
+- [ ] `validator_events` table contains `ClusterMigratedToETH` records for affected validators.
+- [ ] `validators.migration_day` is set for all validators in migrated clusters.
+- [ ] Re-running `sync` (without `--fresh`) does **not** overwrite `migration_day`.
+- [ ] `ValidatorAdded` events **after** the `staking_upgrade` boundary → `migration_day` is set.
+- [ ] `ValidatorAdded` events **before** the boundary → no `migration_day`.
+- [ ] Dual-tree outputs produced correctly (repeat Phase 3 verifications).
+
+---
+
+## Cleanup
+
+After all testing, reset the DB to clean state:
+
+```sql
+UPDATE validators SET migration_day = NULL WHERE migration_day IS NOT NULL;
+```
+
+---
+
+## Merkle generation
+
+```bash
+jq -S . rewards/<period>/cumulative.json > scripts/merkle-generator/scripts/input_1.json
+cd scripts/merkle-generator
+npx hardhat run scripts/generate.js
+# Root + proofs in scripts/output_1.json
+```
+
+Repeat with `cumulative-eth.json` for the ETH tree.
+
+---
+
+## SQL spot-checks
+
+Useful queries for manual verification. Replace the criteria values (`213`, `22`) with the ones from the `mechanics` entry in `rewards.yaml` that covers the round you're testing.
+
+**Compare SSV vs ETH participations for a migrated validator:**
+```sql
+SELECT * FROM participations_by_validator('beaconcha', 213, 22, '2025-09-01', NULL, true, true, true, 'ssv')
+WHERE public_key = '...';
+
+SELECT * FROM participations_by_validator('beaconcha', 213, 22, '2025-09-01', NULL, true, true, true, 'eth')
+WHERE public_key = '...';
+```
+
+**Confirm total days are preserved (SSV + ETH = original):**
+
+> This JOIN only returns validators that appear in **both** trees (i.e., `migration_day` falls within the round month). Validators fully in one tree won't appear.
+
+```sql
+SELECT
+  ssv.active_days AS ssv_active_days,
+  eth.active_days AS eth_active_days,
+  ssv.active_days + eth.active_days AS total_active_days
+FROM participations_by_validator('beaconcha', 213, 22, '2025-09-01', NULL, true, true, true, 'ssv') ssv
+JOIN participations_by_validator('beaconcha', 213, 22, '2025-09-01', NULL, true, true, true, 'eth') eth
+  USING (public_key)
+WHERE ssv.public_key = '...';
+```
+
+**Verify mixed-owner split:**
+```sql
+SELECT * FROM participations_by_owner('beaconcha', 213, 22, '2025-09-01', NULL, true, true, true, 'ssv')
+WHERE owner_address = '...';
+
+SELECT * FROM participations_by_owner('beaconcha', 213, 22, '2025-09-01', NULL, true, true, true, 'eth')
+WHERE owner_address = '...';
+```

--- a/pkg/models/validator_performances.go
+++ b/pkg/models/validator_performances.go
@@ -32,6 +32,7 @@ type ValidatorPerformance struct {
 	PublicKey             string       `boil:"public_key" json:"public_key" toml:"public_key" yaml:"public_key"`
 	SolventWholeDay       bool         `boil:"solvent_whole_day" json:"solvent_whole_day" toml:"solvent_whole_day" yaml:"solvent_whole_day"`
 	Index                 null.Int     `boil:"index" json:"index,omitempty" toml:"index" yaml:"index,omitempty"`
+	EndEffectiveBalance   null.Int64   `boil:"end_effective_balance" json:"end_effective_balance,omitempty" toml:"end_effective_balance" yaml:"end_effective_balance,omitempty"`
 	StartBeaconStatus     null.String  `boil:"start_beacon_status" json:"start_beacon_status,omitempty" toml:"start_beacon_status" yaml:"start_beacon_status,omitempty"`
 	EndBeaconStatus       null.String  `boil:"end_beacon_status" json:"end_beacon_status,omitempty" toml:"end_beacon_status" yaml:"end_beacon_status,omitempty"`
 	Decideds              null.Int     `boil:"decideds" json:"decideds,omitempty" toml:"decideds" yaml:"decideds,omitempty"`
@@ -46,7 +47,6 @@ type ValidatorPerformance struct {
 	SyncCommitteeAssigned null.Int16   `boil:"sync_committee_assigned" json:"sync_committee_assigned,omitempty" toml:"sync_committee_assigned" yaml:"sync_committee_assigned,omitempty"`
 	SyncCommitteeExecuted null.Int16   `boil:"sync_committee_executed" json:"sync_committee_executed,omitempty" toml:"sync_committee_executed" yaml:"sync_committee_executed,omitempty"`
 	SyncCommitteeMissed   null.Int16   `boil:"sync_committee_missed" json:"sync_committee_missed,omitempty" toml:"sync_committee_missed" yaml:"sync_committee_missed,omitempty"`
-	EndEffectiveBalance   null.Int64   `boil:"end_effective_balance" json:"end_effective_balance,omitempty" toml:"end_effective_balance" yaml:"end_effective_balance,omitempty"`
 
 	R *validatorPerformanceR `boil:"-" json:"-" toml:"-" yaml:"-"`
 	L validatorPerformanceL  `boil:"-" json:"-" toml:"-" yaml:"-"`
@@ -61,6 +61,7 @@ var ValidatorPerformanceColumns = struct {
 	PublicKey             string
 	SolventWholeDay       string
 	Index                 string
+	EndEffectiveBalance   string
 	StartBeaconStatus     string
 	EndBeaconStatus       string
 	Decideds              string
@@ -75,7 +76,6 @@ var ValidatorPerformanceColumns = struct {
 	SyncCommitteeAssigned string
 	SyncCommitteeExecuted string
 	SyncCommitteeMissed   string
-	EndEffectiveBalance   string
 }{
 	Provider:              "provider",
 	Day:                   "day",
@@ -85,6 +85,7 @@ var ValidatorPerformanceColumns = struct {
 	PublicKey:             "public_key",
 	SolventWholeDay:       "solvent_whole_day",
 	Index:                 "index",
+	EndEffectiveBalance:   "end_effective_balance",
 	StartBeaconStatus:     "start_beacon_status",
 	EndBeaconStatus:       "end_beacon_status",
 	Decideds:              "decideds",
@@ -99,7 +100,6 @@ var ValidatorPerformanceColumns = struct {
 	SyncCommitteeAssigned: "sync_committee_assigned",
 	SyncCommitteeExecuted: "sync_committee_executed",
 	SyncCommitteeMissed:   "sync_committee_missed",
-	EndEffectiveBalance:   "end_effective_balance",
 }
 
 var ValidatorPerformanceTableColumns = struct {
@@ -111,6 +111,7 @@ var ValidatorPerformanceTableColumns = struct {
 	PublicKey             string
 	SolventWholeDay       string
 	Index                 string
+	EndEffectiveBalance   string
 	StartBeaconStatus     string
 	EndBeaconStatus       string
 	Decideds              string
@@ -125,7 +126,6 @@ var ValidatorPerformanceTableColumns = struct {
 	SyncCommitteeAssigned string
 	SyncCommitteeExecuted string
 	SyncCommitteeMissed   string
-	EndEffectiveBalance   string
 }{
 	Provider:              "validator_performances.provider",
 	Day:                   "validator_performances.day",
@@ -135,6 +135,7 @@ var ValidatorPerformanceTableColumns = struct {
 	PublicKey:             "validator_performances.public_key",
 	SolventWholeDay:       "validator_performances.solvent_whole_day",
 	Index:                 "validator_performances.index",
+	EndEffectiveBalance:   "validator_performances.end_effective_balance",
 	StartBeaconStatus:     "validator_performances.start_beacon_status",
 	EndBeaconStatus:       "validator_performances.end_beacon_status",
 	Decideds:              "validator_performances.decideds",
@@ -149,7 +150,6 @@ var ValidatorPerformanceTableColumns = struct {
 	SyncCommitteeAssigned: "validator_performances.sync_committee_assigned",
 	SyncCommitteeExecuted: "validator_performances.sync_committee_executed",
 	SyncCommitteeMissed:   "validator_performances.sync_committee_missed",
-	EndEffectiveBalance:   "validator_performances.end_effective_balance",
 }
 
 // Generated where
@@ -227,6 +227,44 @@ func (w whereHelpernull_Int) NIN(slice []int) qm.QueryMod {
 func (w whereHelpernull_Int) IsNull() qm.QueryMod    { return qmhelper.WhereIsNull(w.field) }
 func (w whereHelpernull_Int) IsNotNull() qm.QueryMod { return qmhelper.WhereIsNotNull(w.field) }
 
+type whereHelpernull_Int64 struct{ field string }
+
+func (w whereHelpernull_Int64) EQ(x null.Int64) qm.QueryMod {
+	return qmhelper.WhereNullEQ(w.field, false, x)
+}
+func (w whereHelpernull_Int64) NEQ(x null.Int64) qm.QueryMod {
+	return qmhelper.WhereNullEQ(w.field, true, x)
+}
+func (w whereHelpernull_Int64) LT(x null.Int64) qm.QueryMod {
+	return qmhelper.Where(w.field, qmhelper.LT, x)
+}
+func (w whereHelpernull_Int64) LTE(x null.Int64) qm.QueryMod {
+	return qmhelper.Where(w.field, qmhelper.LTE, x)
+}
+func (w whereHelpernull_Int64) GT(x null.Int64) qm.QueryMod {
+	return qmhelper.Where(w.field, qmhelper.GT, x)
+}
+func (w whereHelpernull_Int64) GTE(x null.Int64) qm.QueryMod {
+	return qmhelper.Where(w.field, qmhelper.GTE, x)
+}
+func (w whereHelpernull_Int64) IN(slice []int64) qm.QueryMod {
+	values := make([]interface{}, 0, len(slice))
+	for _, value := range slice {
+		values = append(values, value)
+	}
+	return qm.WhereIn(fmt.Sprintf("%s IN ?", w.field), values...)
+}
+func (w whereHelpernull_Int64) NIN(slice []int64) qm.QueryMod {
+	values := make([]interface{}, 0, len(slice))
+	for _, value := range slice {
+		values = append(values, value)
+	}
+	return qm.WhereNotIn(fmt.Sprintf("%s NOT IN ?", w.field), values...)
+}
+
+func (w whereHelpernull_Int64) IsNull() qm.QueryMod    { return qmhelper.WhereIsNull(w.field) }
+func (w whereHelpernull_Int64) IsNotNull() qm.QueryMod { return qmhelper.WhereIsNotNull(w.field) }
+
 type whereHelpernull_Float32 struct{ field string }
 
 func (w whereHelpernull_Float32) EQ(x null.Float32) qm.QueryMod {
@@ -303,44 +341,6 @@ func (w whereHelpernull_Int16) NIN(slice []int16) qm.QueryMod {
 func (w whereHelpernull_Int16) IsNull() qm.QueryMod    { return qmhelper.WhereIsNull(w.field) }
 func (w whereHelpernull_Int16) IsNotNull() qm.QueryMod { return qmhelper.WhereIsNotNull(w.field) }
 
-type whereHelpernull_Int64 struct{ field string }
-
-func (w whereHelpernull_Int64) EQ(x null.Int64) qm.QueryMod {
-	return qmhelper.WhereNullEQ(w.field, false, x)
-}
-func (w whereHelpernull_Int64) NEQ(x null.Int64) qm.QueryMod {
-	return qmhelper.WhereNullEQ(w.field, true, x)
-}
-func (w whereHelpernull_Int64) LT(x null.Int64) qm.QueryMod {
-	return qmhelper.Where(w.field, qmhelper.LT, x)
-}
-func (w whereHelpernull_Int64) LTE(x null.Int64) qm.QueryMod {
-	return qmhelper.Where(w.field, qmhelper.LTE, x)
-}
-func (w whereHelpernull_Int64) GT(x null.Int64) qm.QueryMod {
-	return qmhelper.Where(w.field, qmhelper.GT, x)
-}
-func (w whereHelpernull_Int64) GTE(x null.Int64) qm.QueryMod {
-	return qmhelper.Where(w.field, qmhelper.GTE, x)
-}
-func (w whereHelpernull_Int64) IN(slice []int64) qm.QueryMod {
-	values := make([]interface{}, 0, len(slice))
-	for _, value := range slice {
-		values = append(values, value)
-	}
-	return qm.WhereIn(fmt.Sprintf("%s IN ?", w.field), values...)
-}
-func (w whereHelpernull_Int64) NIN(slice []int64) qm.QueryMod {
-	values := make([]interface{}, 0, len(slice))
-	for _, value := range slice {
-		values = append(values, value)
-	}
-	return qm.WhereNotIn(fmt.Sprintf("%s NOT IN ?", w.field), values...)
-}
-
-func (w whereHelpernull_Int64) IsNull() qm.QueryMod    { return qmhelper.WhereIsNull(w.field) }
-func (w whereHelpernull_Int64) IsNotNull() qm.QueryMod { return qmhelper.WhereIsNotNull(w.field) }
-
 var ValidatorPerformanceWhere = struct {
 	Provider              whereHelperProviderType
 	Day                   whereHelpertime_Time
@@ -350,6 +350,7 @@ var ValidatorPerformanceWhere = struct {
 	PublicKey             whereHelperstring
 	SolventWholeDay       whereHelperbool
 	Index                 whereHelpernull_Int
+	EndEffectiveBalance   whereHelpernull_Int64
 	StartBeaconStatus     whereHelpernull_String
 	EndBeaconStatus       whereHelpernull_String
 	Decideds              whereHelpernull_Int
@@ -364,7 +365,6 @@ var ValidatorPerformanceWhere = struct {
 	SyncCommitteeAssigned whereHelpernull_Int16
 	SyncCommitteeExecuted whereHelpernull_Int16
 	SyncCommitteeMissed   whereHelpernull_Int16
-	EndEffectiveBalance   whereHelpernull_Int64
 }{
 	Provider:              whereHelperProviderType{field: "\"validator_performances\".\"provider\""},
 	Day:                   whereHelpertime_Time{field: "\"validator_performances\".\"day\""},
@@ -374,6 +374,7 @@ var ValidatorPerformanceWhere = struct {
 	PublicKey:             whereHelperstring{field: "\"validator_performances\".\"public_key\""},
 	SolventWholeDay:       whereHelperbool{field: "\"validator_performances\".\"solvent_whole_day\""},
 	Index:                 whereHelpernull_Int{field: "\"validator_performances\".\"index\""},
+	EndEffectiveBalance:   whereHelpernull_Int64{field: "\"validator_performances\".\"end_effective_balance\""},
 	StartBeaconStatus:     whereHelpernull_String{field: "\"validator_performances\".\"start_beacon_status\""},
 	EndBeaconStatus:       whereHelpernull_String{field: "\"validator_performances\".\"end_beacon_status\""},
 	Decideds:              whereHelpernull_Int{field: "\"validator_performances\".\"decideds\""},
@@ -388,7 +389,6 @@ var ValidatorPerformanceWhere = struct {
 	SyncCommitteeAssigned: whereHelpernull_Int16{field: "\"validator_performances\".\"sync_committee_assigned\""},
 	SyncCommitteeExecuted: whereHelpernull_Int16{field: "\"validator_performances\".\"sync_committee_executed\""},
 	SyncCommitteeMissed:   whereHelpernull_Int16{field: "\"validator_performances\".\"sync_committee_missed\""},
-	EndEffectiveBalance:   whereHelpernull_Int64{field: "\"validator_performances\".\"end_effective_balance\""},
 }
 
 // ValidatorPerformanceRels is where relationship names are stored.
@@ -419,9 +419,9 @@ func (r *validatorPerformanceR) GetPublicKeyValidator() *Validator {
 type validatorPerformanceL struct{}
 
 var (
-	validatorPerformanceAllColumns            = []string{"provider", "day", "from_epoch", "to_epoch", "owner_address", "public_key", "solvent_whole_day", "index", "start_beacon_status", "end_beacon_status", "decideds", "effectiveness", "attestation_rate", "attestations_assigned", "attestations_executed", "attestations_missed", "proposals_assigned", "proposals_executed", "proposals_missed", "sync_committee_assigned", "sync_committee_executed", "sync_committee_missed", "end_effective_balance"}
+	validatorPerformanceAllColumns            = []string{"provider", "day", "from_epoch", "to_epoch", "owner_address", "public_key", "solvent_whole_day", "index", "end_effective_balance", "start_beacon_status", "end_beacon_status", "decideds", "effectiveness", "attestation_rate", "attestations_assigned", "attestations_executed", "attestations_missed", "proposals_assigned", "proposals_executed", "proposals_missed", "sync_committee_assigned", "sync_committee_executed", "sync_committee_missed"}
 	validatorPerformanceColumnsWithoutDefault = []string{"provider", "day", "from_epoch", "to_epoch", "owner_address", "public_key", "solvent_whole_day"}
-	validatorPerformanceColumnsWithDefault    = []string{"index", "start_beacon_status", "end_beacon_status", "decideds", "effectiveness", "attestation_rate", "attestations_assigned", "attestations_executed", "attestations_missed", "proposals_assigned", "proposals_executed", "proposals_missed", "sync_committee_assigned", "sync_committee_executed", "sync_committee_missed", "end_effective_balance"}
+	validatorPerformanceColumnsWithDefault    = []string{"index", "end_effective_balance", "start_beacon_status", "end_beacon_status", "decideds", "effectiveness", "attestation_rate", "attestations_assigned", "attestations_executed", "attestations_missed", "proposals_assigned", "proposals_executed", "proposals_missed", "sync_committee_assigned", "sync_committee_executed", "sync_committee_missed"}
 	validatorPerformancePrimaryKeyColumns     = []string{"provider", "day", "public_key"}
 	validatorPerformanceGeneratedColumns      = []string{}
 )

--- a/pkg/models/validators.go
+++ b/pkg/models/validators.go
@@ -34,6 +34,7 @@ type Validator struct {
 	BeaconExitEpoch                  null.Int    `boil:"beacon_exit_epoch" json:"beacon_exit_epoch,omitempty" toml:"beacon_exit_epoch" yaml:"beacon_exit_epoch,omitempty"`
 	BeaconSlashed                    null.Bool   `boil:"beacon_slashed" json:"beacon_slashed,omitempty" toml:"beacon_slashed" yaml:"beacon_slashed,omitempty"`
 	BeaconWithdrawableEpoch          null.Int    `boil:"beacon_withdrawable_epoch" json:"beacon_withdrawable_epoch,omitempty" toml:"beacon_withdrawable_epoch" yaml:"beacon_withdrawable_epoch,omitempty"`
+	MigrationDay                     null.Time   `boil:"migration_day" json:"migration_day,omitempty" toml:"migration_day" yaml:"migration_day,omitempty"`
 
 	R *validatorR `boil:"-" json:"-" toml:"-" yaml:"-"`
 	L validatorL  `boil:"-" json:"-" toml:"-" yaml:"-"`
@@ -50,6 +51,7 @@ var ValidatorColumns = struct {
 	BeaconExitEpoch                  string
 	BeaconSlashed                    string
 	BeaconWithdrawableEpoch          string
+	MigrationDay                     string
 }{
 	PublicKey:                        "public_key",
 	Index:                            "index",
@@ -61,6 +63,7 @@ var ValidatorColumns = struct {
 	BeaconExitEpoch:                  "beacon_exit_epoch",
 	BeaconSlashed:                    "beacon_slashed",
 	BeaconWithdrawableEpoch:          "beacon_withdrawable_epoch",
+	MigrationDay:                     "migration_day",
 }
 
 var ValidatorTableColumns = struct {
@@ -74,6 +77,7 @@ var ValidatorTableColumns = struct {
 	BeaconExitEpoch                  string
 	BeaconSlashed                    string
 	BeaconWithdrawableEpoch          string
+	MigrationDay                     string
 }{
 	PublicKey:                        "validators.public_key",
 	Index:                            "validators.index",
@@ -85,6 +89,7 @@ var ValidatorTableColumns = struct {
 	BeaconExitEpoch:                  "validators.beacon_exit_epoch",
 	BeaconSlashed:                    "validators.beacon_slashed",
 	BeaconWithdrawableEpoch:          "validators.beacon_withdrawable_epoch",
+	MigrationDay:                     "validators.migration_day",
 }
 
 // Generated where
@@ -124,6 +129,7 @@ var ValidatorWhere = struct {
 	BeaconExitEpoch                  whereHelpernull_Int
 	BeaconSlashed                    whereHelpernull_Bool
 	BeaconWithdrawableEpoch          whereHelpernull_Int
+	MigrationDay                     whereHelpernull_Time
 }{
 	PublicKey:                        whereHelperstring{field: "\"validators\".\"public_key\""},
 	Index:                            whereHelpernull_Int{field: "\"validators\".\"index\""},
@@ -135,6 +141,7 @@ var ValidatorWhere = struct {
 	BeaconExitEpoch:                  whereHelpernull_Int{field: "\"validators\".\"beacon_exit_epoch\""},
 	BeaconSlashed:                    whereHelpernull_Bool{field: "\"validators\".\"beacon_slashed\""},
 	BeaconWithdrawableEpoch:          whereHelpernull_Int{field: "\"validators\".\"beacon_withdrawable_epoch\""},
+	MigrationDay:                     whereHelpernull_Time{field: "\"validators\".\"migration_day\""},
 }
 
 // ValidatorRels is where relationship names are stored.
@@ -185,9 +192,9 @@ func (r *validatorR) GetPublicKeyValidatorPerformances() ValidatorPerformanceSli
 type validatorL struct{}
 
 var (
-	validatorAllColumns            = []string{"public_key", "index", "active", "beacon_status", "beacon_effective_balance", "beacon_activation_eligibility_epoch", "beacon_activation_epoch", "beacon_exit_epoch", "beacon_slashed", "beacon_withdrawable_epoch"}
+	validatorAllColumns            = []string{"public_key", "index", "active", "beacon_status", "beacon_effective_balance", "beacon_activation_eligibility_epoch", "beacon_activation_epoch", "beacon_exit_epoch", "beacon_slashed", "beacon_withdrawable_epoch", "migration_day"}
 	validatorColumnsWithoutDefault = []string{"public_key", "active"}
-	validatorColumnsWithDefault    = []string{"index", "beacon_status", "beacon_effective_balance", "beacon_activation_eligibility_epoch", "beacon_activation_epoch", "beacon_exit_epoch", "beacon_slashed", "beacon_withdrawable_epoch"}
+	validatorColumnsWithDefault    = []string{"index", "beacon_status", "beacon_effective_balance", "beacon_activation_eligibility_epoch", "beacon_activation_epoch", "beacon_exit_epoch", "beacon_slashed", "beacon_withdrawable_epoch", "migration_day"}
 	validatorPrimaryKeyColumns     = []string{"public_key"}
 	validatorGeneratedColumns      = []string{}
 )

--- a/pkg/rewards/eth_migration.go
+++ b/pkg/rewards/eth_migration.go
@@ -1,0 +1,11 @@
+package rewards
+
+import "github.com/ethereum/go-ethereum/crypto"
+
+// ClusterMigratedToETHEvent is the event name for cluster ETH-fee migration.
+const ClusterMigratedToETHEvent = "ClusterMigratedToETH"
+
+// ClusterMigratedToETHTopic is keccak256 of the ClusterMigratedToETH event signature.
+var ClusterMigratedToETHTopic = crypto.Keccak256Hash([]byte(
+	"ClusterMigratedToETH(address,uint64[],uint256,uint256,uint32,(uint32,uint64,uint64,bool,uint256))",
+))

--- a/pkg/rewards/plan.go
+++ b/pkg/rewards/plan.go
@@ -38,6 +38,15 @@ type Plan struct {
 	//   - Constant daily rewards (daily = annual/365, then monthly = daily * days_in_month)
 	// Default: defaultLegacyCalculationCutoff (2025-08)
 	LegacyCalculationCutoff Period `yaml:"legacy_calculation_cutoff,omitempty"`
+
+	StakingUpgrade *StakingUpgrade `yaml:"staking_upgrade,omitempty"`
+}
+
+// StakingUpgrade is the on-chain event position that separates pre-upgrade
+// validators (SSV reward tree) from post-upgrade validators (ETH reward tree).
+type StakingUpgrade struct {
+	Block    int `yaml:"block"`
+	LogIndex int `yaml:"log_index"`
 }
 
 // ParsePlan parses the given YAML document into a Plan.
@@ -122,6 +131,16 @@ func (p *Plan) validate() error {
 				return fmt.Errorf("failed to load validator redirects from file %q: %w", mechanics.ValidatorRedirectsFile, err)
 			}
 			mechanics.ValidatorRedirects = loadedRedirects
+		}
+	}
+
+	// Validate upgrade boundary.
+	if p.StakingUpgrade != nil {
+		if p.StakingUpgrade.Block <= 0 {
+			return errors.New("staking_upgrade.block must be positive")
+		}
+		if p.StakingUpgrade.LogIndex < 0 {
+			return errors.New("staking_upgrade.log_index must be non-negative")
 		}
 	}
 

--- a/pkg/rewards/plan_test.go
+++ b/pkg/rewards/plan_test.go
@@ -309,6 +309,79 @@ func TestPlan_Validate(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "staking_upgrade block must be positive",
+			plan: &Plan{
+				Mechanics: MechanicsList{
+					{
+						Since:    NewPeriod(2020, 1),
+						Criteria: Criteria{MinAttestationsPerDay: 1, MinDecidedsPerDay: 1},
+						Tiers:    Tiers{{MaxEffectiveBalance: precise.NewETH64(32), APRBoost: mustParseETH("0.1")}},
+					},
+				},
+				Rounds:         Rounds{{Period: NewPeriod(2020, 1)}},
+				StakingUpgrade: &StakingUpgrade{Block: 0, LogIndex: 5},
+			},
+			expectedErr: "staking_upgrade.block must be positive",
+		},
+		{
+			name: "staking_upgrade negative block",
+			plan: &Plan{
+				Mechanics: MechanicsList{
+					{
+						Since:    NewPeriod(2020, 1),
+						Criteria: Criteria{MinAttestationsPerDay: 1, MinDecidedsPerDay: 1},
+						Tiers:    Tiers{{MaxEffectiveBalance: precise.NewETH64(32), APRBoost: mustParseETH("0.1")}},
+					},
+				},
+				Rounds:         Rounds{{Period: NewPeriod(2020, 1)}},
+				StakingUpgrade: &StakingUpgrade{Block: -1, LogIndex: 0},
+			},
+			expectedErr: "staking_upgrade.block must be positive",
+		},
+		{
+			name: "staking_upgrade log_index must be non-negative",
+			plan: &Plan{
+				Mechanics: MechanicsList{
+					{
+						Since:    NewPeriod(2020, 1),
+						Criteria: Criteria{MinAttestationsPerDay: 1, MinDecidedsPerDay: 1},
+						Tiers:    Tiers{{MaxEffectiveBalance: precise.NewETH64(32), APRBoost: mustParseETH("0.1")}},
+					},
+				},
+				Rounds:         Rounds{{Period: NewPeriod(2020, 1)}},
+				StakingUpgrade: &StakingUpgrade{Block: 100, LogIndex: -1},
+			},
+			expectedErr: "staking_upgrade.log_index must be non-negative",
+		},
+		{
+			name: "valid plan with staking_upgrade",
+			plan: &Plan{
+				Mechanics: MechanicsList{
+					{
+						Since:    NewPeriod(2020, 1),
+						Criteria: Criteria{MinAttestationsPerDay: 1, MinDecidedsPerDay: 1},
+						Tiers:    Tiers{{MaxEffectiveBalance: precise.NewETH64(32), APRBoost: mustParseETH("0.1")}},
+					},
+				},
+				Rounds:         Rounds{{Period: NewPeriod(2020, 1)}},
+				StakingUpgrade: &StakingUpgrade{Block: 100, LogIndex: 0},
+			},
+		},
+		{
+			name: "valid plan with staking_upgrade non-zero log_index",
+			plan: &Plan{
+				Mechanics: MechanicsList{
+					{
+						Since:    NewPeriod(2020, 1),
+						Criteria: Criteria{MinAttestationsPerDay: 1, MinDecidedsPerDay: 1},
+						Tiers:    Tiers{{MaxEffectiveBalance: precise.NewETH64(32), APRBoost: mustParseETH("0.1")}},
+					},
+				},
+				Rounds:         Rounds{{Period: NewPeriod(2020, 1)}},
+				StakingUpgrade: &StakingUpgrade{Block: 12345678, LogIndex: 42},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/sync/cluster_migration.go
+++ b/pkg/sync/cluster_migration.go
@@ -1,17 +1,18 @@
 package sync
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"strings"
 	"time"
 
-	operatorstorage "github.com/bloxapp/ssv/operator/storage"
+	"github.com/bloxapp/ssv/eth/eventparser"
 	ssvtypes "github.com/bloxapp/ssv/protocol/v2/types"
-	registrystorage "github.com/bloxapp/ssv/registry/storage"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -62,13 +63,13 @@ var clusterMigratedToETHABI = func() abi.Event {
 	return parsed.Events["ClusterMigratedToETH"]
 }()
 
-// handleClusterMigration processes a ClusterMigratedToETH event by setting migration_day
-// on all validators in the cluster and inserting validator_events records.
+// handleClusterMigration processes a ClusterMigratedToETH event by setting
+// migration_day on all validators in the cluster and inserting validator_events
+// records.
 func handleClusterMigration(
 	ctx context.Context,
 	logger *zap.Logger,
 	db *sql.DB,
-	nodeStorage operatorstorage.Storage,
 	log *types.Log,
 	contractEvent *models.ContractEvent,
 	migratedClusters map[string]struct{},
@@ -76,20 +77,16 @@ func handleClusterMigration(
 	if len(log.Topics) < 2 {
 		return fmt.Errorf("malformed ClusterMigratedToETH log: expected >= 2 topics, got %d", len(log.Topics))
 	}
-
-	// Parse owner from Topics[1] (indexed address, padded to 32 bytes).
 	owner := common.BytesToAddress(log.Topics[1].Bytes())
 
-	// Decode non-indexed event data.
 	decoded, err := clusterMigratedToETHABI.Inputs.Unpack(log.Data)
 	if err != nil {
 		return fmt.Errorf("decode ClusterMigratedToETH data: %w", err)
 	}
 	operatorIds := decoded[0].([]uint64)
 
-	// Decode validatorCount from cluster tuple (6th event param, first field).
-	clusterData := decoded[4]
-	clusterStruct, ok := clusterData.(struct {
+	// validatorCount lives in the cluster tuple (5th non-indexed input, first field).
+	clusterStruct, ok := decoded[4].(struct {
 		ValidatorCount  uint32   `json:"validatorCount"`
 		NetworkFeeIndex uint64   `json:"networkFeeIndex"`
 		Index           uint64   `json:"index"`
@@ -97,20 +94,18 @@ func handleClusterMigration(
 		Balance         *big.Int `json:"balance"`
 	})
 	if !ok {
-		return fmt.Errorf("unexpected cluster tuple type: %T", clusterData)
+		return fmt.Errorf("unexpected cluster tuple type: %T", decoded[4])
 	}
 	validatorCount := clusterStruct.ValidatorCount
 
-	// Compute cluster ID.
 	clusterID, err := ssvtypes.ComputeClusterIDHash(owner.Bytes(), operatorIds)
 	if err != nil {
 		return fmt.Errorf("compute cluster ID: %w", err)
 	}
 	clusterIDStr := hex.EncodeToString(clusterID)
 
-	// In-memory dedup: warn on duplicate within same sync run.
 	if _, exists := migratedClusters[clusterIDStr]; exists {
-		logger.Warn("duplicate ClusterMigratedToETH in same sync run (A4 invariant)",
+		logger.Warn("duplicate ClusterMigratedToETH in same sync run",
 			zap.String("cluster_id", clusterIDStr),
 			zap.Uint64("block_number", log.BlockNumber),
 		)
@@ -118,34 +113,37 @@ func handleClusterMigration(
 	}
 	migratedClusters[clusterIDStr] = struct{}{}
 
-	// Look up affected validators.
-	shares := nodeStorage.Shares().List(nil, registrystorage.ByClusterID(clusterID))
+	members, err := computeClusterMembersAt(
+		ctx, db, owner, clusterID, int(log.BlockNumber), int(log.Index),
+	)
+	if err != nil {
+		return fmt.Errorf("compute cluster members at migration position: %w", err)
+	}
 
-	if len(shares) == 0 && validatorCount == 0 {
+	if len(members) == 0 && validatorCount == 0 {
 		logger.Warn("migrated cluster has no validators",
 			zap.String("cluster_id", clusterIDStr),
 			zap.String("owner", strings.ToLower(owner.Hex())),
 		)
-	} else if len(shares) != int(validatorCount) {
-		logger.Warn("share count differs from on-chain validatorCount",
+		return nil
+	} else if len(members) != int(validatorCount) {
+		logger.Warn("local member count differs from on-chain validatorCount",
 			zap.String("cluster_id", clusterIDStr),
-			zap.Int("local_shares", len(shares)),
+			zap.Int("local_members", len(members)),
 			zap.Uint32("chain_validator_count", validatorCount))
 	}
 
 	migrationDay := contractEvent.BlockTime.UTC().Truncate(24 * time.Hour)
 
-	// Wrap all DB writes in a single transaction.
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	for _, share := range shares {
-		pubKey := hex.EncodeToString(share.ValidatorPubKey)
-
-		// Set migration_day. IS NULL guard prevents overwriting on cross-run duplicates.
+	for _, pubKey := range members {
+		// IS NULL guard preserves an earlier migration_day if the validator
+		// already transitioned to the ETH tree via a prior cluster.
 		_, err := models.Validators(
 			models.ValidatorWhere.PublicKey.EQ(pubKey),
 			models.ValidatorWhere.MigrationDay.IsNull(),
@@ -173,4 +171,109 @@ func handleClusterMigration(
 	}
 
 	return tx.Commit()
+}
+
+// computeClusterMembersAt returns the public keys of validators in the cluster
+// identified by targetClusterID at the chain position (migBlock, migLogIndex),
+// derived from validator_events ordered by (block_number, log_index).
+//
+// A pubkey is a member if the latest of its ValidatorAdded/ValidatorRemoved
+// events whose cluster_id matches targetClusterID and whose position is strictly
+// before (migBlock, migLogIndex) is a ValidatorAdded.
+func computeClusterMembersAt(
+	ctx context.Context,
+	db *sql.DB,
+	owner common.Address,
+	targetClusterID []byte,
+	migBlock, migLogIndex int,
+) ([]string, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT ve.public_key, ve.event_name,
+		       ce.raw_event::jsonb -> 'OperatorIds' AS op_ids
+		FROM validator_events ve
+		JOIN contract_events ce ON ce.id = ve.contract_event_id
+		WHERE ve.owner_address = $1
+		  AND ve.event_name IN ('ValidatorAdded', 'ValidatorRemoved')
+		  AND (ve.block_number < $2
+		       OR (ve.block_number = $2 AND ve.log_index < $3))
+		ORDER BY ve.block_number, ve.log_index
+	`,
+		strings.ToLower(owner.Hex()[2:]),
+		migBlock, migLogIndex,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query cluster member events: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	events := make([]clusterMemberEvent, 0)
+	for rows.Next() {
+		var (
+			pubKey, eventName string
+			opIdsJSON         []byte
+		)
+		if err := rows.Scan(&pubKey, &eventName, &opIdsJSON); err != nil {
+			return nil, fmt.Errorf("scan cluster member event: %w", err)
+		}
+
+		var ops []uint64
+		if err := json.Unmarshal(opIdsJSON, &ops); err != nil {
+			return nil, fmt.Errorf("unmarshal operator ids: %w", err)
+		}
+
+		events = append(events, clusterMemberEvent{
+			PublicKey: pubKey,
+			EventName: eventName,
+			OperatorIds: ops,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate cluster member events: %w", err)
+	}
+
+	return reduceClusterMembers(owner, targetClusterID, events)
+}
+
+// clusterMemberEvent is a decoded ValidatorAdded or ValidatorRemoved event,
+// shaped for consumption by reduceClusterMembers without a DB or ABI dependency.
+type clusterMemberEvent struct {
+	PublicKey   string
+	EventName   string
+	OperatorIds []uint64
+}
+
+// reduceClusterMembers walks events in order and returns the public keys
+// currently in targetClusterID: a pubkey is a member if its latest event
+// whose computed cluster_id equals targetClusterID is a ValidatorAdded.
+func reduceClusterMembers(
+	owner common.Address,
+	targetClusterID []byte,
+	events []clusterMemberEvent,
+) ([]string, error) {
+	members := map[string]struct{}{}
+	for _, ev := range events {
+		// ComputeClusterIDHash sorts operatorIds in place; copy to avoid
+		// mutating the caller's slice.
+		ops := append([]uint64(nil), ev.OperatorIds...)
+		cid, err := ssvtypes.ComputeClusterIDHash(owner.Bytes(), ops)
+		if err != nil {
+			return nil, fmt.Errorf("compute cluster id: %w", err)
+		}
+		if !bytes.Equal(cid, targetClusterID) {
+			continue
+		}
+
+		switch ev.EventName {
+		case eventparser.ValidatorAdded:
+			members[ev.PublicKey] = struct{}{}
+		case eventparser.ValidatorRemoved:
+			delete(members, ev.PublicKey)
+		}
+	}
+
+	out := make([]string, 0, len(members))
+	for pk := range members {
+		out = append(out, pk)
+	}
+	return out, nil
 }

--- a/pkg/sync/cluster_migration.go
+++ b/pkg/sync/cluster_migration.go
@@ -121,15 +121,16 @@ func handleClusterMigration(
 	// Look up affected validators.
 	shares := nodeStorage.Shares().List(nil, registrystorage.ByClusterID(clusterID))
 
-	// Validate share count against on-chain validatorCount.
 	if len(shares) == 0 && validatorCount == 0 {
 		logger.Warn("migrated cluster has no validators",
 			zap.String("cluster_id", clusterIDStr),
 			zap.String("owner", strings.ToLower(owner.Hex())),
 		)
 	} else if len(shares) != int(validatorCount) {
-		return fmt.Errorf("share count (%d) differs from validatorCount (%d) for cluster %s — run: sync --fresh --keep-cache",
-			len(shares), validatorCount, clusterIDStr)
+		logger.Warn("share count differs from on-chain validatorCount",
+			zap.String("cluster_id", clusterIDStr),
+			zap.Int("local_shares", len(shares)),
+			zap.Uint32("chain_validator_count", validatorCount))
 	}
 
 	migrationDay := contractEvent.BlockTime.UTC().Truncate(24 * time.Hour)

--- a/pkg/sync/cluster_migration.go
+++ b/pkg/sync/cluster_migration.go
@@ -1,0 +1,175 @@
+package sync
+
+import (
+	"context"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+
+	operatorstorage "github.com/bloxapp/ssv/operator/storage"
+	ssvtypes "github.com/bloxapp/ssv/protocol/v2/types"
+	registrystorage "github.com/bloxapp/ssv/registry/storage"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/volatiletech/sqlboiler/v4/boil"
+	"go.uber.org/zap"
+
+	"github.com/bloxapp/ssv-rewards/pkg/models"
+	"github.com/bloxapp/ssv-rewards/pkg/rewards"
+)
+
+// isPostStakingUpgrade returns true if the log is at or after the configured upgrade boundary.
+func isPostStakingUpgrade(log *types.Log, upgrade *rewards.StakingUpgrade) bool {
+	if upgrade == nil {
+		return false
+	}
+	blockNum := int(log.BlockNumber)
+	return blockNum > upgrade.Block ||
+		(blockNum == upgrade.Block && int(log.Index) >= upgrade.LogIndex)
+}
+
+// clusterMigratedToETHJSON is the JSON ABI for the ClusterMigratedToETH event.
+const clusterMigratedToETHJSON = `[{
+	"anonymous": false,
+	"inputs": [
+		{"indexed": true,  "name": "owner",            "type": "address"},
+		{"indexed": false, "name": "operatorIds",      "type": "uint64[]"},
+		{"indexed": false, "name": "ethDeposited",     "type": "uint256"},
+		{"indexed": false, "name": "ssvRefunded",      "type": "uint256"},
+		{"indexed": false, "name": "effectiveBalance", "type": "uint32"},
+		{"indexed": false, "name": "cluster",          "type": "tuple",
+		 "components": [
+			{"name": "validatorCount",  "type": "uint32"},
+			{"name": "networkFeeIndex", "type": "uint64"},
+			{"name": "index",           "type": "uint64"},
+			{"name": "active",          "type": "bool"},
+			{"name": "balance",         "type": "uint256"}
+		]}
+	],
+	"name": "ClusterMigratedToETH",
+	"type": "event"
+}]`
+
+var clusterMigratedToETHABI = func() abi.Event {
+	parsed, err := abi.JSON(strings.NewReader(clusterMigratedToETHJSON))
+	if err != nil {
+		panic(fmt.Sprintf("parse ClusterMigratedToETH ABI: %v", err))
+	}
+	return parsed.Events["ClusterMigratedToETH"]
+}()
+
+// handleClusterMigration processes a ClusterMigratedToETH event by setting migration_day
+// on all validators in the cluster and inserting validator_events records.
+func handleClusterMigration(
+	ctx context.Context,
+	logger *zap.Logger,
+	db *sql.DB,
+	nodeStorage operatorstorage.Storage,
+	log *types.Log,
+	contractEvent *models.ContractEvent,
+	migratedClusters map[string]struct{},
+) error {
+	if len(log.Topics) < 2 {
+		return fmt.Errorf("malformed ClusterMigratedToETH log: expected >= 2 topics, got %d", len(log.Topics))
+	}
+
+	// Parse owner from Topics[1] (indexed address, padded to 32 bytes).
+	owner := common.BytesToAddress(log.Topics[1].Bytes())
+
+	// Decode non-indexed event data.
+	decoded, err := clusterMigratedToETHABI.Inputs.Unpack(log.Data)
+	if err != nil {
+		return fmt.Errorf("decode ClusterMigratedToETH data: %w", err)
+	}
+	operatorIds := decoded[0].([]uint64)
+
+	// Decode validatorCount from cluster tuple (6th event param, first field).
+	clusterData := decoded[4]
+	clusterStruct, ok := clusterData.(struct {
+		ValidatorCount  uint32   `json:"validatorCount"`
+		NetworkFeeIndex uint64   `json:"networkFeeIndex"`
+		Index           uint64   `json:"index"`
+		Active          bool     `json:"active"`
+		Balance         *big.Int `json:"balance"`
+	})
+	if !ok {
+		return fmt.Errorf("unexpected cluster tuple type: %T", clusterData)
+	}
+	validatorCount := clusterStruct.ValidatorCount
+
+	// Compute cluster ID.
+	clusterID, err := ssvtypes.ComputeClusterIDHash(owner.Bytes(), operatorIds)
+	if err != nil {
+		return fmt.Errorf("compute cluster ID: %w", err)
+	}
+	clusterIDStr := hex.EncodeToString(clusterID)
+
+	// In-memory dedup: warn on duplicate within same sync run.
+	if _, exists := migratedClusters[clusterIDStr]; exists {
+		logger.Warn("duplicate ClusterMigratedToETH in same sync run (A4 invariant)",
+			zap.String("cluster_id", clusterIDStr),
+			zap.Uint64("block_number", log.BlockNumber),
+		)
+		return nil
+	}
+	migratedClusters[clusterIDStr] = struct{}{}
+
+	// Look up affected validators.
+	shares := nodeStorage.Shares().List(nil, registrystorage.ByClusterID(clusterID))
+
+	// Validate share count against on-chain validatorCount.
+	if len(shares) == 0 && validatorCount == 0 {
+		logger.Warn("migrated cluster has no validators",
+			zap.String("cluster_id", clusterIDStr),
+			zap.String("owner", strings.ToLower(owner.Hex())),
+		)
+	} else if len(shares) != int(validatorCount) {
+		return fmt.Errorf("share count (%d) differs from validatorCount (%d) for cluster %s — run: sync --fresh --keep-cache",
+			len(shares), validatorCount, clusterIDStr)
+	}
+
+	migrationDay := contractEvent.BlockTime.UTC().Truncate(24 * time.Hour)
+
+	// Wrap all DB writes in a single transaction.
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	for _, share := range shares {
+		pubKey := hex.EncodeToString(share.ValidatorPubKey)
+
+		// Set migration_day. IS NULL guard prevents overwriting on cross-run duplicates.
+		_, err := models.Validators(
+			models.ValidatorWhere.PublicKey.EQ(pubKey),
+			models.ValidatorWhere.MigrationDay.IsNull(),
+		).UpdateAll(ctx, tx, models.M{
+			models.ValidatorColumns.MigrationDay: migrationDay,
+		})
+		if err != nil {
+			return fmt.Errorf("set migration_day: %w", err)
+		}
+
+		validatorEvent := models.ValidatorEvent{
+			ContractEventID: contractEvent.ID,
+			Slot:            contractEvent.Slot,
+			BlockNumber:     int(log.BlockNumber),
+			BlockTime:       contractEvent.BlockTime,
+			LogIndex:        int(log.Index),
+			EventName:       rewards.ClusterMigratedToETHEvent,
+			OwnerAddress:    strings.ToLower(owner.Hex()[2:]),
+			PublicKey:       pubKey,
+			Activated:       true,
+		}
+		if err := validatorEvent.Insert(ctx, tx, boil.Infer()); err != nil {
+			return fmt.Errorf("insert validator event: %w", err)
+		}
+	}
+
+	return tx.Commit()
+}

--- a/pkg/sync/cluster_migration_test.go
+++ b/pkg/sync/cluster_migration_test.go
@@ -1,0 +1,191 @@
+package sync
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bloxapp/ssv-rewards/pkg/rewards"
+)
+
+func TestIsPostStakingUpgrade(t *testing.T) {
+	upgrade := &rewards.StakingUpgrade{Block: 100, LogIndex: 5}
+
+	tests := []struct {
+		name     string
+		log      *types.Log
+		upgrade  *rewards.StakingUpgrade
+		expected bool
+	}{
+		{
+			name:     "nil upgrade",
+			log:      &types.Log{BlockNumber: 200, Index: 10},
+			upgrade:  nil,
+			expected: false,
+		},
+		{
+			name:     "before upgrade block",
+			log:      &types.Log{BlockNumber: 99, Index: 10},
+			upgrade:  upgrade,
+			expected: false,
+		},
+		{
+			name:     "same block, before log_index",
+			log:      &types.Log{BlockNumber: 100, Index: 4},
+			upgrade:  upgrade,
+			expected: false,
+		},
+		{
+			name:     "same block, at log_index",
+			log:      &types.Log{BlockNumber: 100, Index: 5},
+			upgrade:  upgrade,
+			expected: true,
+		},
+		{
+			name:     "same block, after log_index",
+			log:      &types.Log{BlockNumber: 100, Index: 6},
+			upgrade:  upgrade,
+			expected: true,
+		},
+		{
+			name:     "after upgrade block",
+			log:      &types.Log{BlockNumber: 101, Index: 0},
+			upgrade:  upgrade,
+			expected: true,
+		},
+		{
+			name:     "after upgrade block, log_index irrelevant",
+			log:      &types.Log{BlockNumber: 200, Index: 0},
+			upgrade:  upgrade,
+			expected: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, isPostStakingUpgrade(tt.log, tt.upgrade))
+		})
+	}
+}
+
+func TestClusterMigratedToETHTopic(t *testing.T) {
+	// Hardcoded digest guards against accidental changes to the event signature in eth_migration.go.
+	expected := common.HexToHash("0x6dc71e7231318932a8a7f99bac76f94ffe24cac147843e0c285ce4cf290c803a")
+	require.Equal(t, expected, rewards.ClusterMigratedToETHTopic)
+}
+
+func TestClusterMigratedToETHABIDecode(t *testing.T) {
+	// Encode known values using the same ABI definition.
+	eventABI := clusterMigratedToETHABI
+
+	operatorIds := []uint64{1, 2, 3, 4}
+	ethDeposited := big.NewInt(1e18)
+	ssvRefunded := big.NewInt(2e18)
+	effectiveBalance := uint32(32)
+
+	type clusterTuple struct {
+		ValidatorCount  uint32   `json:"validatorCount"`
+		NetworkFeeIndex uint64   `json:"networkFeeIndex"`
+		Index           uint64   `json:"index"`
+		Active          bool     `json:"active"`
+		Balance         *big.Int `json:"balance"`
+	}
+	cluster := clusterTuple{
+		ValidatorCount:  7,
+		NetworkFeeIndex: 100,
+		Index:           200,
+		Active:          true,
+		Balance:         big.NewInt(5e18),
+	}
+
+	// Pack only the non-indexed inputs (owner is indexed → in Topics).
+	data, err := eventABI.Inputs.NonIndexed().Pack(
+		operatorIds,
+		ethDeposited,
+		ssvRefunded,
+		effectiveBalance,
+		cluster,
+	)
+	require.NoError(t, err)
+
+	// Build a synthetic log.
+	owner := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+	log := &types.Log{
+		Topics: []common.Hash{
+			rewards.ClusterMigratedToETHTopic,
+			common.BytesToHash(owner.Bytes()),
+		},
+		Data: data,
+	}
+
+	// Decode non-indexed data (same as production code).
+	decoded, err := eventABI.Inputs.Unpack(log.Data)
+	require.NoError(t, err)
+	require.Len(t, decoded, 5)
+
+	// Verify operatorIds.
+	gotOps, ok := decoded[0].([]uint64)
+	require.True(t, ok, "operatorIds type: %T", decoded[0])
+	require.Equal(t, operatorIds, gotOps)
+
+	// Verify ethDeposited.
+	gotEthDeposited, ok := decoded[1].(*big.Int)
+	require.True(t, ok, "ethDeposited type: %T", decoded[1])
+	require.Equal(t, ethDeposited, gotEthDeposited)
+
+	// Verify ssvRefunded.
+	gotSsvRefunded, ok := decoded[2].(*big.Int)
+	require.True(t, ok, "ssvRefunded type: %T", decoded[2])
+	require.Equal(t, ssvRefunded, gotSsvRefunded)
+
+	// Verify effectiveBalance.
+	gotEffectiveBalance, ok := decoded[3].(uint32)
+	require.True(t, ok, "effectiveBalance type: %T", decoded[3])
+	require.Equal(t, effectiveBalance, gotEffectiveBalance)
+
+	// Verify cluster tuple via the same struct assertion used in production.
+	clusterData := decoded[4]
+	clusterStruct, ok := clusterData.(struct {
+		ValidatorCount  uint32   `json:"validatorCount"`
+		NetworkFeeIndex uint64   `json:"networkFeeIndex"`
+		Index           uint64   `json:"index"`
+		Active          bool     `json:"active"`
+		Balance         *big.Int `json:"balance"`
+	})
+	require.True(t, ok, "cluster tuple type: %T", clusterData)
+	require.Equal(t, uint32(7), clusterStruct.ValidatorCount)
+	require.Equal(t, uint64(100), clusterStruct.NetworkFeeIndex)
+	require.Equal(t, uint64(200), clusterStruct.Index)
+	require.True(t, clusterStruct.Active)
+	require.Equal(t, big.NewInt(5e18), clusterStruct.Balance)
+
+	// Verify owner from Topics[1].
+	gotOwner := common.BytesToAddress(log.Topics[1].Bytes())
+	require.Equal(t, owner, gotOwner)
+}
+
+func TestClusterMigratedToETHABIParsing(t *testing.T) {
+	// Verify the ABI JSON parses without panic and has the expected structure.
+	event := clusterMigratedToETHABI
+
+	require.Equal(t, "ClusterMigratedToETH", event.Name)
+	require.Len(t, event.Inputs, 6)
+
+	// First input: owner (indexed).
+	require.Equal(t, "owner", event.Inputs[0].Name)
+	require.True(t, event.Inputs[0].Indexed)
+	require.Equal(t, abi.AddressTy, event.Inputs[0].Type.T)
+
+	// Second input: operatorIds (not indexed, uint64[]).
+	require.Equal(t, "operatorIds", event.Inputs[1].Name)
+	require.False(t, event.Inputs[1].Indexed)
+	require.Equal(t, abi.SliceTy, event.Inputs[1].Type.T)
+
+	// Last input: cluster tuple (not indexed).
+	require.Equal(t, "cluster", event.Inputs[5].Name)
+	require.False(t, event.Inputs[5].Indexed)
+	require.Equal(t, abi.TupleTy, event.Inputs[5].Type.T)
+}

--- a/pkg/sync/cluster_migration_test.go
+++ b/pkg/sync/cluster_migration_test.go
@@ -2,8 +2,11 @@ package sync
 
 import (
 	"math/big"
+	"sort"
 	"testing"
 
+	"github.com/bloxapp/ssv/eth/eventparser"
+	ssvtypes "github.com/bloxapp/ssv/protocol/v2/types"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -188,4 +191,156 @@ func TestClusterMigratedToETHABIParsing(t *testing.T) {
 	require.Equal(t, "cluster", event.Inputs[5].Name)
 	require.False(t, event.Inputs[5].Indexed)
 	require.Equal(t, abi.TupleTy, event.Inputs[5].Type.T)
+}
+
+// Test fixtures for reduceClusterMembers.
+//
+// The owner under test owns two clusters (A and B) with disjoint operator sets;
+// the targetClusterID below points at cluster A. Cluster B's events should
+// always be skipped by the reducer.
+var (
+	rcmOwner = common.HexToAddress("0x38e3df07e1ff499393fcd918c661ca8e7b00f53c")
+	rcmOpsA  = []uint64{2222, 2224, 2226, 2227}
+	rcmOpsB  = []uint64{2222, 2223, 2224, 2225}
+
+	pkV1 = "ab" + "00" + "11"   // any non-empty distinct strings; reducer doesn't care about format
+	pkV2 = "cd" + "22" + "33"
+	pkV3 = "ef" + "44" + "55"
+)
+
+func rcmTargetClusterID(t *testing.T) []byte {
+	t.Helper()
+	cid, err := ssvtypes.ComputeClusterIDHash(rcmOwner.Bytes(), append([]uint64{}, rcmOpsA...))
+	require.NoError(t, err)
+	return cid
+}
+
+func add(pubkey string, ops []uint64) clusterMemberEvent {
+	return clusterMemberEvent{PublicKey: pubkey, EventName: eventparser.ValidatorAdded, OperatorIds: ops}
+}
+
+func rem(pubkey string, ops []uint64) clusterMemberEvent {
+	return clusterMemberEvent{PublicKey: pubkey, EventName: eventparser.ValidatorRemoved, OperatorIds: ops}
+}
+
+func TestReduceClusterMembers(t *testing.T) {
+	target := rcmTargetClusterID(t)
+
+	tests := []struct {
+		name     string
+		events   []clusterMemberEvent
+		expected []string
+	}{
+		{
+			name:     "empty input → empty members",
+			events:   nil,
+			expected: []string{},
+		},
+		{
+			name: "add before mig → in members",
+			events: []clusterMemberEvent{
+				add(pkV1, rcmOpsA),
+			},
+			expected: []string{pkV1},
+		},
+		{
+			name: "add then remove before mig → empty members",
+			events: []clusterMemberEvent{
+				add(pkV1, rcmOpsA),
+				rem(pkV1, rcmOpsA),
+			},
+			expected: []string{},
+		},
+		{
+			name: "add, remove, re-add to same cluster → in members",
+			events: []clusterMemberEvent{
+				add(pkV1, rcmOpsA),
+				rem(pkV1, rcmOpsA),
+				add(pkV1, rcmOpsA),
+			},
+			expected: []string{pkV1},
+		},
+		{
+			name: "duplicate adds (same pubkey, same cluster) → idempotent, single membership",
+			events: []clusterMemberEvent{
+				add(pkV1, rcmOpsA),
+				add(pkV1, rcmOpsA),
+			},
+			expected: []string{pkV1},
+		},
+		{
+			name: "events for a different cluster (B) are ignored",
+			events: []clusterMemberEvent{
+				add(pkV2, rcmOpsB),
+				rem(pkV2, rcmOpsB),
+				add(pkV3, rcmOpsB),
+			},
+			expected: []string{},
+		},
+		{
+			name: "interleaved A and B events — only A counted",
+			events: []clusterMemberEvent{
+				add(pkV1, rcmOpsA), // counted, V1 in A
+				add(pkV2, rcmOpsB), // skipped
+				add(pkV3, rcmOpsA), // counted, V3 in A
+				rem(pkV2, rcmOpsB), // skipped
+			},
+			expected: []string{pkV1, pkV3},
+		},
+		{
+			name: "operator IDs in non-sorted order still match (ComputeClusterIDHash sorts)",
+			events: []clusterMemberEvent{
+				add(pkV1, []uint64{rcmOpsA[3], rcmOpsA[0], rcmOpsA[2], rcmOpsA[1]}),
+			},
+			expected: []string{pkV1},
+		},
+		{
+			name: "remove before any add (chain shouldn't emit this, but be defensive) → empty",
+			events: []clusterMemberEvent{
+				rem(pkV1, rcmOpsA),
+			},
+			expected: []string{},
+		},
+		{
+			name: "mix: V1 added in A, V2 added then removed in A, V3 added in B (ignored)",
+			events: []clusterMemberEvent{
+				add(pkV1, rcmOpsA),
+				add(pkV2, rcmOpsA),
+				rem(pkV2, rcmOpsA),
+				add(pkV3, rcmOpsB),
+			},
+			expected: []string{pkV1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := reduceClusterMembers(rcmOwner, target, tt.events)
+			require.NoError(t, err)
+
+			// Map iteration is nondeterministic; sort both sides for comparison.
+			sort.Strings(got)
+			expected := append([]string{}, tt.expected...)
+			sort.Strings(expected)
+			require.Equal(t, expected, got)
+		})
+	}
+}
+
+// TestReduceClusterMembers_OperatorIdsSliceNotMutated confirms the reducer
+// doesn't mutate the caller's OperatorIds slice. Important because
+// ssvtypes.ComputeClusterIDHash sorts in place; we pass a defensive copy.
+func TestReduceClusterMembers_OperatorIdsSliceNotMutated(t *testing.T) {
+	target := rcmTargetClusterID(t)
+
+	// Pass a deliberately unsorted slice. Capture what we pass; assert it
+	// remains unchanged after the reducer runs.
+	unsorted := []uint64{rcmOpsA[3], rcmOpsA[0], rcmOpsA[2], rcmOpsA[1]}
+	original := append([]uint64{}, unsorted...)
+
+	_, err := reduceClusterMembers(rcmOwner, target, []clusterMemberEvent{
+		add(pkV1, unsorted),
+	})
+	require.NoError(t, err)
+	require.Equal(t, original, unsorted, "caller's OperatorIds slice was mutated")
 }

--- a/pkg/sync/validator_events.go
+++ b/pkg/sync/validator_events.go
@@ -332,7 +332,7 @@ func recordHandledEvents(
 			if eventTrace.Error != nil {
 				// Check if this is a ClusterMigratedToETH event we can handle ourselves.
 				if len(eventTrace.Log.Topics) > 0 && eventTrace.Log.Topics[0] == rewards.ClusterMigratedToETHTopic {
-					if err := handleClusterMigration(ctx, logger, db, nodeStorage, eventTrace.Log, databaseEvent, migratedClusters); err != nil {
+					if err := handleClusterMigration(ctx, logger, db, eventTrace.Log, databaseEvent, migratedClusters); err != nil {
 						return fmt.Errorf("handle cluster migration: %w", err)
 					}
 					// Clear the error and set event_name since we handled it.

--- a/pkg/sync/validator_events.go
+++ b/pkg/sync/validator_events.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	eth2client "github.com/attestantio/go-eth2-client"
 	"github.com/attestantio/go-eth2-client/api"
@@ -32,6 +33,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/bloxapp/ssv-rewards/pkg/models"
+	"github.com/bloxapp/ssv-rewards/pkg/rewards"
 )
 
 func SyncValidatorEvents(
@@ -42,6 +44,7 @@ func SyncValidatorEvents(
 	nodeStorage operatorstorage.Storage,
 	db *sql.DB,
 	cl eth2client.Service,
+	stakingUpgrade *rewards.StakingUpgrade,
 ) error {
 	// Fetch events from the database, organize into a channel of BlockLogs
 	// and process them using SSV's EventHandler.
@@ -102,7 +105,7 @@ func SyncValidatorEvents(
 	// Spawn handled event recorder.
 	eventTraces := make(chan eventhandler.EventTrace, 1024)
 	backgroundTasks.Go(func(ctx context.Context) (err error) {
-		if err := recordHandledEvents(ctx, logger, db, nodeStorage, eventTraces); err != nil {
+		if err := recordHandledEvents(ctx, logger, db, nodeStorage, eventTraces, stakingUpgrade); err != nil {
 			return fmt.Errorf("failed to record handled event: %w", err)
 		}
 		return nil
@@ -262,7 +265,8 @@ func SyncValidatorEvents(
 				int(beaconValidator.Validator.WithdrawableEpoch),
 			)
 		}
-		if err := validator.Upsert(ctx, db, true, []string{"public_key"}, boil.Infer(), boil.Infer()); err != nil {
+		// Blacklist migration_day on update to preserve values set by cluster migration or post-upgrade add.
+		if err := validator.Upsert(ctx, db, true, []string{"public_key"}, boil.Blacklist("migration_day"), boil.Infer()); err != nil {
 			return fmt.Errorf("failed to upsert validator: %w", err)
 		}
 	}
@@ -275,8 +279,10 @@ func recordHandledEvents(
 	db *sql.DB,
 	nodeStorage operatorstorage.Storage,
 	eventTraces <-chan eventhandler.EventTrace,
+	stakingUpgrade *rewards.StakingUpgrade,
 ) error {
 	recordedEvents := 0
+	migratedClusters := make(map[string]struct{})
 	defer func() {
 		// Read from eventTraces until it's closed to avoid clogging EventHandler.
 		go func() {
@@ -313,11 +319,8 @@ func recordHandledEvents(
 				return fmt.Errorf("failed to update event: %w", sql.ErrNoRows)
 			}
 
-			// Insert ValidatorEvent(s).
-			if eventTrace.Error != nil {
-				continue
-			}
-			recordedEvents++
+			// Fetch databaseEvent before error check — needed for both migration
+			// handling and regular event processing.
 			databaseEvent, err := models.ContractEvents(
 				models.ContractEventWhere.BlockNumber.EQ(int(eventTrace.Log.BlockNumber)),
 				models.ContractEventWhere.LogIndex.EQ(int(eventTrace.Log.Index)),
@@ -325,11 +328,38 @@ func recordHandledEvents(
 			if err != nil {
 				return fmt.Errorf("failed to match ContractEvent: %w", err)
 			}
+
+			if eventTrace.Error != nil {
+				// Check if this is a ClusterMigratedToETH event we can handle ourselves.
+				if len(eventTrace.Log.Topics) > 0 && eventTrace.Log.Topics[0] == rewards.ClusterMigratedToETHTopic {
+					if err := handleClusterMigration(ctx, logger, db, nodeStorage, eventTrace.Log, databaseEvent, migratedClusters); err != nil {
+						return fmt.Errorf("handle cluster migration: %w", err)
+					}
+					// Clear the error and set event_name since we handled it.
+					n, err := models.ContractEvents(
+						models.ContractEventWhere.ID.EQ(databaseEvent.ID),
+					).UpdateAll(ctx, db, models.M{
+						models.ContractEventColumns.Error:     sql.NullString{},
+						models.ContractEventColumns.EventName: rewards.ClusterMigratedToETHEvent,
+					})
+					if err != nil {
+						return fmt.Errorf("clear contract event error: %w", err)
+					}
+					if n != 1 {
+						return fmt.Errorf("clear contract event error: expected 1 row, got %d", n)
+					}
+					recordedEvents++
+				}
+				continue
+			}
+
+			recordedEvents++
 			var (
-				eventName    string
-				pubKeys      []string
-				ownerAddress common.Address
-				activated    bool
+				eventName              string
+				pubKeys                []string
+				ownerAddress           common.Address
+				activated              bool
+				addedPostStakingUpgrade *time.Time
 			)
 			switch v := eventTrace.Event.(type) {
 			case *contract.ContractValidatorAdded:
@@ -337,6 +367,10 @@ func recordHandledEvents(
 				activated = true
 				ownerAddress = v.Owner
 				pubKeys = []string{hex.EncodeToString(v.PublicKey)}
+				if isPostStakingUpgrade(eventTrace.Log, stakingUpgrade) {
+					addDay := databaseEvent.BlockTime.UTC().Truncate(24 * time.Hour)
+					addedPostStakingUpgrade = &addDay
+				}
 			case *contract.ContractValidatorRemoved:
 				eventName = eventparser.ValidatorRemoved
 				activated = false
@@ -376,6 +410,20 @@ func recordHandledEvents(
 				}
 				if err := validator.Upsert(ctx, db, false, []string{"public_key"}, boil.None(), boil.Whitelist("public_key", "active")); err != nil {
 					return fmt.Errorf("failed to upsert validator: %w", err)
+				}
+
+				// Post-upgrade ValidatorAdded: set migration_day to the add day.
+				// IS NULL guard prevents overwriting if already set (e.g., from ClusterMigratedToETH).
+				if addedPostStakingUpgrade != nil {
+					_, err := models.Validators(
+						models.ValidatorWhere.PublicKey.EQ(pubKey),
+						models.ValidatorWhere.MigrationDay.IsNull(),
+					).UpdateAll(ctx, db, models.M{
+						models.ValidatorColumns.MigrationDay: *addedPostStakingUpgrade,
+					})
+					if err != nil {
+						return fmt.Errorf("set migration_day for post-upgrade add: %w", err)
+					}
 				}
 
 				validatorEvent := models.ValidatorEvent{

--- a/pkg/sync/validator_performance.go
+++ b/pkg/sync/validator_performance.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/bloxapp/ssv-rewards/pkg/beacon"
 	"github.com/bloxapp/ssv-rewards/pkg/models"
+	"github.com/bloxapp/ssv-rewards/pkg/rewards"
 	"github.com/bloxapp/ssv-rewards/pkg/sync/httpretry"
 	"github.com/bloxapp/ssv-rewards/pkg/sync/performance"
 )
@@ -189,7 +190,7 @@ func SyncValidatorPerformance(
 				}
 			case eventparser.ValidatorRemoved:
 				delete(activeValidators, pk)
-			case eventparser.ClusterLiquidated, eventparser.ClusterReactivated:
+			case eventparser.ClusterLiquidated, eventparser.ClusterReactivated, rewards.ClusterMigratedToETHEvent:
 				// Ignore.
 			default:
 				return fmt.Errorf("unexpected validator event: %s", event.EventName)

--- a/rewards.example.yaml
+++ b/rewards.example.yaml
@@ -1,5 +1,12 @@
 version: 2
 
+# Optional: Upgrade boundary for ETH-fee cluster migration.
+# Set to the (block, log_index) of the staking module upgrade event.
+# ValidatorAdded events at or after this position belong to the ETH reward tree.
+# staking_upgrade:
+#   block: 22345678
+#   log_index: 42
+
 mechanics:
   - since: 2023-07
     criteria:

--- a/rewards.sql
+++ b/rewards.sql
@@ -1,3 +1,10 @@
+-- Drop old function signatures to prevent overloaded ambiguity.
+-- Required because CREATE OR REPLACE with a new parameter count creates a new overload.
+DROP FUNCTION IF EXISTS participations_by_validator(provider_type, INTEGER, INTEGER, DATE, DATE, BOOLEAN, BOOLEAN, BOOLEAN);
+DROP FUNCTION IF EXISTS participations_by_recipient(provider_type, INTEGER, INTEGER, DATE, DATE, BOOLEAN, BOOLEAN, BOOLEAN);
+DROP FUNCTION IF EXISTS participations_by_owner(provider_type, INTEGER, INTEGER, DATE, DATE, BOOLEAN, BOOLEAN, BOOLEAN);
+DROP FUNCTION IF EXISTS exclusions_by_validator(provider_type, INTEGER, INTEGER, DATE, DATE);
+
 CREATE OR REPLACE FUNCTION participations_by_validator(
     _provider provider_type,
     min_attestations INTEGER,
@@ -6,7 +13,8 @@ CREATE OR REPLACE FUNCTION participations_by_validator(
     to_period DATE DEFAULT NULL,
     owner_redirects_support BOOLEAN DEFAULT FALSE,
     validator_redirects_support BOOLEAN DEFAULT FALSE,
-    pectra_support BOOLEAN DEFAULT FALSE
+    pectra_support BOOLEAN DEFAULT FALSE,
+    migration_filter TEXT DEFAULT 'ssv'
 )
 RETURNS TABLE (
     recipient_address TEXT,
@@ -39,9 +47,17 @@ BEGIN
         FROM validator_performances vp
         LEFT JOIN validator_redirects vr ON validator_redirects_support AND vp.public_key = vr.public_key
         LEFT JOIN owner_redirects owr ON owner_redirects_support AND vp.owner_address = owr.from_address
+        LEFT JOIN validators v ON vp.public_key = v.public_key
         WHERE vp.provider = _provider
           AND vp.day >= _from_month AND vp.day < (_to_month + INTERVAL '1 month')
           AND vp.solvent_whole_day
+          AND (
+              CASE migration_filter
+                  WHEN 'ssv' THEN (v.migration_day IS NULL OR vp.day < v.migration_day)
+                  WHEN 'eth' THEN (v.migration_day IS NOT NULL AND vp.day >= v.migration_day)
+                  ELSE FALSE
+              END
+          )
     )
     SELECT
         vpr.recipient_address,
@@ -65,7 +81,8 @@ CREATE OR REPLACE FUNCTION participations_by_recipient(
     to_period DATE DEFAULT NULL,
     owner_redirects_support BOOLEAN DEFAULT FALSE,
     validator_redirects_support BOOLEAN DEFAULT FALSE,
-    pectra_support BOOLEAN DEFAULT FALSE
+    pectra_support BOOLEAN DEFAULT FALSE,
+    migration_filter TEXT DEFAULT 'ssv'
 )
 RETURNS TABLE (
     recipient_address TEXT,
@@ -92,7 +109,8 @@ BEGIN
         to_period,
         owner_redirects_support,
         validator_redirects_support,
-        pectra_support
+        pectra_support,
+        migration_filter
     ) adv
     GROUP BY adv.recipient_address;
 END;
@@ -106,7 +124,8 @@ CREATE OR REPLACE FUNCTION participations_by_owner(
     to_period DATE DEFAULT NULL,
     owner_redirects_support BOOLEAN DEFAULT FALSE,
     validator_redirects_support BOOLEAN DEFAULT FALSE,
-    pectra_support BOOLEAN DEFAULT FALSE
+    pectra_support BOOLEAN DEFAULT FALSE,
+    migration_filter TEXT DEFAULT 'ssv'
 )
 RETURNS TABLE (
     recipient_address TEXT,
@@ -135,7 +154,8 @@ BEGIN
         to_period,
         owner_redirects_support,
         validator_redirects_support,
-        pectra_support
+        pectra_support,
+        migration_filter
     ) adv
     GROUP BY adv.owner_address, adv.recipient_address;
 END;
@@ -146,7 +166,8 @@ CREATE OR REPLACE FUNCTION exclusions_by_validator(
     min_attestations INTEGER,
     min_decideds INTEGER,
     from_period DATE,
-    to_period DATE default NULL
+    to_period DATE default NULL,
+    migration_filter TEXT DEFAULT 'ssv'
 )
 RETURNS TABLE (
 	day DATE,
@@ -180,9 +201,17 @@ BEGIN
                 ELSE 'unknown'
             END AS exclusion_reason
         FROM validator_performances AS vp
+        LEFT JOIN validators val ON vp.public_key = val.public_key
         WHERE provider = _provider
           AND vp.day >= _from_month AND vp.day < (_to_month + INTERVAL '1 month')
           AND (NOT solvent_whole_day OR attestations_executed < min_attestations OR decideds < min_decideds)
+          AND (
+              CASE migration_filter
+                  WHEN 'ssv' THEN (val.migration_day IS NULL OR vp.day < val.migration_day)
+                  WHEN 'eth' THEN (val.migration_day IS NOT NULL AND vp.day >= val.migration_day)
+                  ELSE FALSE
+              END
+          )
     )
     SELECT
     	v.day,

--- a/schema.sql
+++ b/schema.sql
@@ -35,8 +35,14 @@ CREATE TABLE IF NOT EXISTS validators (
 	beacon_exit_epoch INT,
 	beacon_slashed BOOLEAN,
 	beacon_withdrawable_epoch INT,
+	-- NULL = SSV tree. Non-NULL = ETH tree from this day onward.
+	-- Set by ClusterMigratedToETH (cluster's migration day) or
+	-- post-upgrade ValidatorAdded (the add day).
+	migration_day DATE,
 	PRIMARY KEY (public_key)
 );
+
+ALTER TABLE validators ADD COLUMN IF NOT EXISTS migration_day DATE;
 
 CREATE TABLE IF NOT EXISTS validator_events (
     id SERIAL PRIMARY KEY,


### PR DESCRIPTION
The `EXECUTION_ENDPOINT` limits the max number of logs per response for the `eth_getLogs` JSON-RPC method to 20000 by default and we're hitting the limit while syncing contract events:
```
ssv-rewards: error: failed to sync contract events: failed to fetch logs: 503 Service Unavailable: {"jsonrpc":"2.0","error":{"code":-32005,"message":"Too many logs requested. Max logs per response is 20000."},"id":469}
```

The failure is a log-count limit, not a block-range limit. Our RPC caps each `eth_getLogs` response at 20,000 logs, while the sync path batches by blocks and can request far more logs in one call.

Solution: 
The minimal change is to reduce `logBatchSize` at client creation. For production syncs across the full mainnet history, adaptive batching is the right fix so we don’t have to guess a batch size that works for every era of chain activity.